### PR TITLE
add limits to abbreviations

### DIFF
--- a/abbreviation_extraction/abbreviations.py
+++ b/abbreviation_extraction/abbreviations.py
@@ -144,8 +144,12 @@ def filter_matches(
             long_form_candidate = doc[
                 max(start - max_words - 1 - quote_offset, 0) : start - 1 - quote_offset
             ]
-            candidates.append((long_form_candidate, doc[start:end]))
+
+            if len(str(doc[start:end])) >= 3: 
+                candidates.append((long_form_candidate, doc[start:end]))
+
             continue
+
     return candidates
 
 
@@ -156,7 +160,6 @@ def short_form_filter(span: Span) -> bool:
     # At least one word is alpha numeric
     if not any([x.is_alpha for x in span]):
         return False
-    
 
     return True
 
@@ -169,7 +172,17 @@ def verify_match_format(
         BRACKETS = ["(", ")"]
         start = match[1]
         end = match[2] - 1
+
+        # verify that the match is wrapped in quotes and brackets
         if not contains(str(doc[start+1]), QUOTES) or not contains(str(doc[end-1]), QUOTES) or not contains(str(doc[start]), BRACKETS) or not contains (str(doc[end]), BRACKETS): 
+            matcher_output.remove(match)
+
+        first_char = str(doc[start+2])
+        last_char = str(doc[end-2])
+        abbreviation_length = len(last_char)
+
+        # verify that the start and end of the abbreviation contains upper case
+        if first_char[0].isupper() is not True or last_char[abbreviation_length-1].isupper() is not True: 
             matcher_output.remove(match)
     
     return matcher_output

--- a/abbreviation_extraction/abbreviations_matcher.py
+++ b/abbreviation_extraction/abbreviations_matcher.py
@@ -7,6 +7,8 @@ AbbreviationDetector class and the pipeline.
 from collections import namedtuple
 import spacy
 from spacy.language import Language
+import sys 
+sys.path.append("./")
 from abbreviation_extraction.abbreviations import AbbreviationDetector
 
 abb = namedtuple('abb', 'abb_match longform')
@@ -48,4 +50,3 @@ def abb_pipeline(judgment_content_text, nlp):
             REPLACEMENTS_ABBR.append(abr_tuple)
 
     return REPLACEMENTS_ABBR
-    


### PR DESCRIPTION
first and last character must be capitals and the length must be >= 3 characters