### PR TITLE
fix abbreviations - not catching capitals at end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ lambda/determine_replacements_abbreviations/workspace.code-workspace
 *.xml
 legislation_provisions_extraction/test_judgments
 legislation_provisions_extraction/output
+abbreviation_extraction/abbreviations_matcher_test.py

--- a/abbreviation_extraction/abbreviations.py
+++ b/abbreviation_extraction/abbreviations.py
@@ -115,7 +115,7 @@ def filter_matches(
         start = match[1]
         end = match[2]
         quote_offset = 0
-        
+
         # Adjust indexes where match is enclosed in quotation marks.
         if contains(doc[start:end].text, QUOTES):
             start = match[1] + 1
@@ -144,9 +144,29 @@ def filter_matches(
             long_form_candidate = doc[
                 max(start - max_words - 1 - quote_offset, 0) : start - 1 - quote_offset
             ]
+            
+            short_form = str(doc[start:end])
+            word = short_form
+            quote_offset_new = 0
+            # Occassionally quotations at the start of the short form slips through - this is to clean that 
+            if short_form.startswith('"') or short_form.startswith("“") or short_form.startswith("”") or short_form.startswith("“"):
+                word = short_form[1:]
+                quote_offset_new = 1
 
+            short_form_clean = word  # use the clean short form if we return the match
+            first_char = short_form_clean[0] # this is the first character of the word
+    
+            last_char = str(doc[end-1]) 
+            length = len(last_char) # use the length to get the index of the last char
+
+            if first_char.isupper() is not True or last_char[length-1].isupper() is not True:
+                continue
+
+
+
+            # abbreviation must have 3 or more characters
             if len(str(doc[start:end])) >= 3: 
-                candidates.append((long_form_candidate, doc[start:end]))
+                candidates.append((long_form_candidate, doc[start+quote_offset_new:end]))
 
             continue
 
@@ -177,8 +197,12 @@ def verify_match_format(
         last_char = str(doc[end-2])
         abbreviation_length = len(last_char)
 
+        if end - start > 8: 
+
+            matcher_output.remove(match)
+
         # verify that the match is wrapped in quotes and brackets
-        if not contains(str(doc[start+1]), QUOTES) or not contains(str(doc[end-1]), QUOTES) or not contains(str(doc[start]), BRACKETS) or not contains (str(doc[end]), BRACKETS): 
+        elif not contains(str(doc[start+1]), QUOTES) or not contains(str(doc[end-1]), QUOTES) or not contains(str(doc[start]), BRACKETS) or not contains (str(doc[end]), BRACKETS): 
             matcher_output.remove(match)
 
         # verify that the start and end of the abbreviation contains upper case
@@ -236,9 +260,8 @@ class AbbreviationDetector():
         matcher_output = verify_match_format(matches_brackets, doc)
         matches_no_brackets = [(x[0], x[1] + 1, x[2] - 1) for x in matcher_output]
         filtered = filter_matches(matches_no_brackets, doc)
-
         occurences = self.find_matches_for(filtered, doc)
-        
+
         for (long_form, short_forms) in occurences:
             for short in short_forms:
                 short._.long_form = long_form

--- a/abbreviation_extraction/abbreviations.py
+++ b/abbreviation_extraction/abbreviations.py
@@ -173,16 +173,16 @@ def verify_match_format(
         start = match[1]
         end = match[2] - 1
 
-        # verify that the match is wrapped in quotes and brackets
-        if not contains(str(doc[start+1]), QUOTES) or not contains(str(doc[end-1]), QUOTES) or not contains(str(doc[start]), BRACKETS) or not contains (str(doc[end]), BRACKETS): 
-            matcher_output.remove(match)
-
         first_char = str(doc[start+2])
         last_char = str(doc[end-2])
         abbreviation_length = len(last_char)
 
+        # verify that the match is wrapped in quotes and brackets
+        if not contains(str(doc[start+1]), QUOTES) or not contains(str(doc[end-1]), QUOTES) or not contains(str(doc[start]), BRACKETS) or not contains (str(doc[end]), BRACKETS): 
+            matcher_output.remove(match)
+
         # verify that the start and end of the abbreviation contains upper case
-        if first_char[0].isupper() is not True or last_char[abbreviation_length-1].isupper() is not True: 
+        elif first_char[0].isupper() is not True or last_char[abbreviation_length-1].isupper() is not True: 
             matcher_output.remove(match)
     
     return matcher_output

--- a/abbreviation_extraction/abbreviations_matcher.py
+++ b/abbreviation_extraction/abbreviations_matcher.py
@@ -48,3 +48,4 @@ def abb_pipeline(judgment_content_text, nlp):
             REPLACEMENTS_ABBR.append(abr_tuple)
 
     return REPLACEMENTS_ABBR
+


### PR DESCRIPTION
fixes: 

- [x] ensures that the first and last chars are capitals
- [x] where a quote slips through with the short form, this is removed
- [x] length of the abbreviation MUST be three chars or greater