### PR TITLE
corrected source. DBClusterSnapshotArn (string) --

### DIFF
--- a/lambda/db_backup/index.py
+++ b/lambda/db_backup/index.py
@@ -44,7 +44,7 @@ def lambda_handler(event, context):
         for snapshot in response["DBClusterSnapshots"]:
             if snapshot["DBClusterSnapshotIdentifier"] == snapshot_name:
                 kms_key_id = snapshot["KmsKeyId"]
-                source = snapshot["SourceDBClusterSnapshotArn"]
+                source = snapshot["DBClusterSnapshotArn"]
                 break
 
     except ClientError as e:


### PR DESCRIPTION
The Amazon Resource Name (ARN) for the DB cluster snapshot.

SourceDBClusterSnapshotArn (string) --

If the DB cluster snapshot was copied from a source DB cluster snapshot, the Amazon Resource Name (ARN) for the source DB cluster snapshot, otherwise, a null value.

Signed-off-by: Adam King <adam.king@mdrx.tech>