### PR TITLE
Fix typo in assigning api_endpoint that blocked enrichment pre-PATCH

### DIFF
--- a/lambda/push_enriched_xml/index.py
+++ b/lambda/push_enriched_xml/index.py
@@ -108,7 +108,7 @@ def process_event(sqs_rec):
     if ENVIRONMENT == "staging":
         api_endpoint = "https://api.staging.caselaw.nationalarchives.gov.uk/"
     else:
-        api_endpoint == "https://api.caselaw.nationalarchives.gov.uk/"
+        api_endpoint = "https://api.caselaw.nationalarchives.gov.uk/"
 
     file_content = (
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]


### PR DESCRIPTION
Editors discovered that the Enrichment pipeline was leaving things locked.
We observed the pipeline locking and checking the locks on documents (`fetch_xml`) but no PATCH requests
from trying to upload the document (in `push_enriched_xml`).

The AWS logs for the `push_enriched_xml` lambda (see page 2) said:

```
[ERROR] UnboundLocalError: local variable 'api_endpoint' referenced before assignment
Traceback (most recent call last):
  ...
  File "/var/task/index.py", line 111, in process_event
    api_endpoint == "https://api.caselaw.nationalarchives.gov.uk/"```

so we are fixing that one line so it's an assignment not a test of equality.

Not yet sure about testing etc.