### PR TITLE
Start fixing tests that depend on postgres to depend on test db

### DIFF
--- a/rules/citation_patterns.jsonl
+++ b/rules/citation_patterns.jsonl
@@ -125,6 +125,7 @@
 {"id": "ewca_civ_c", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "ewca"}, {"ORTH": "civ"} , {"LIKE_NUM": true}]}
 {"id": "ewca_civ_d", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "["}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"LIKE_NUM": true}]}
 {"id": "ewca_civ_e", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "]"}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"LIKE_NUM": true}]}
+{"id": "eu_c_case", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C-\\d+\\/\\d+"}}]}
 {"id": "ewca_civ_f", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"LIKE_NUM": true}]}
 {"id": "ewca_civ_g", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"IS_PUNCT":true}, {"LIKE_NUM": true}]}
 {"id": "ewca_civ_h", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "EWCA"}, {"ORTH": "("}, {"ORTH": "Civ"}, {"ORTH": ")"},{"LIKE_NUM": true}]}
@@ -144,7 +145,7 @@
 {"id": "cmlr", "description": "Common Market Law Reports", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"LIKE_NUM": true}, {"ORTH": "CMLR"},{"LIKE_NUM": true}]}
 {"id": "costslr", "description": "Costs Law Reports", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "Costs"},{"ORTH": "LR"},{"LIKE_NUM": true}]}
 {"id": "crappr_volumnal_with_year", "description": "Criminal Appeal Reports (Volumnal Pre-1995)", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"}, {"TEXT": {"REGEX": "\\d+"}}, {"ORTH": "Cr"},{"ORTH": "App"}, {"ORTH": "R"}, {"LIKE_NUM": true}]}
-{"id": "eu_c_case", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C-\\d+\\/\\d+"}}]}
+{"id": "eu_c_case_a", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C\\d+\\/\\d+"}}]}
 {"id": "crappr_volumnal_with_year_a", "description": "Criminal Appeal Reports (Volumnal Pre-1995)", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"}, {"TEXT": {"REGEX": "\\d+"}}, {"ORTH": "Cr"},{"IS_PUNCT": true},{"ORTH": "App"},{"IS_PUNCT": true}, {"ORTH": "R."}, {"LIKE_NUM": true}]}
 {"id": "crappr_annual", "description": "Criminal Appeal Reports (Annual Volumes Post-1995)", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"LIKE_NUM": true},{"ORTH": "Cr"},{"ORTH": "App"}, {"ORTH": "R"}, {"LIKE_NUM": true}]}
 {"id": "crappr_sentencing_annual", "description": "Criminal Appeal Reports (Sentencing) (Annual Volumes Post-1995)", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"LIKE_NUM": true},{"ORTH": "Cr"},{"ORTH": "App"}, {"ORTH": "R"},{"ORTH": "("},{"ORTH": "S"},{"ORTH": ")"}, {"LIKE_NUM": true}]}
@@ -187,9 +188,9 @@
 {"id": "rpc_a", "description": "Reports of Patents Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "R.P.C."},{"LIKE_NUM": true}]}
 {"id": "stc", "description": "Simon's Tax Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "STC"},{"LIKE_NUM": true}]}
 {"id": "taxcases", "description": "Appeal Cases (1875-1890) (ICLR)", "label": "CITATION", "pattern": [{"LIKE_NUM": true},{"ORTH": "TC"}, {"LIKE_NUM": true}]}
-{"id": "eu_c_case_a", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C\\d+\\/\\d+"}}]}
 {"id": "eu_c_case_c", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "case"},{"TEXT": {"REGEX": "C-\\d+\\/\\d+"}}]}
 {"id": "eu_t_case", "description": "Court of Justice of the European Union (T-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "T-\\d+\\/\\d+"}}]}
 {"id": "bcc", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "BCC"},{"LIKE_NUM": true}]}
 {"id": "bcc_a", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"},{"ORTH": "BCC"},{"LIKE_NUM": true}]}
 {"id": "bcc_b", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "B.C.C."},{"LIKE_NUM": true}]}
+{"id": "bcc_c", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"},{"ORTH": "B.C.C."},{"LIKE_NUM": true}]}

--- a/rules/citation_patterns.jsonl
+++ b/rules/citation_patterns.jsonl
@@ -125,7 +125,6 @@
 {"id": "ewca_civ_c", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "ewca"}, {"ORTH": "civ"} , {"LIKE_NUM": true}]}
 {"id": "ewca_civ_d", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "["}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"LIKE_NUM": true}]}
 {"id": "ewca_civ_e", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "]"}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"LIKE_NUM": true}]}
-{"id": "eu_c_case", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C-\\d+\\/\\d+"}}]}
 {"id": "ewca_civ_f", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"LIKE_NUM": true}]}
 {"id": "ewca_civ_g", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "EWCA"}, {"ORTH": "Civ"}, {"IS_PUNCT":true}, {"LIKE_NUM": true}]}
 {"id": "ewca_civ_h", "description": "Court of Appeal (Civil Division)" ,"label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"ORTH": "EWCA"}, {"ORTH": "("}, {"ORTH": "Civ"}, {"ORTH": ")"},{"LIKE_NUM": true}]}
@@ -145,7 +144,7 @@
 {"id": "cmlr", "description": "Common Market Law Reports", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"LIKE_NUM": true}, {"ORTH": "CMLR"},{"LIKE_NUM": true}]}
 {"id": "costslr", "description": "Costs Law Reports", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "Costs"},{"ORTH": "LR"},{"LIKE_NUM": true}]}
 {"id": "crappr_volumnal_with_year", "description": "Criminal Appeal Reports (Volumnal Pre-1995)", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"}, {"TEXT": {"REGEX": "\\d+"}}, {"ORTH": "Cr"},{"ORTH": "App"}, {"ORTH": "R"}, {"LIKE_NUM": true}]}
-{"id": "eu_c_case_a", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C\\d+\\/\\d+"}}]}
+{"id": "eu_c_case", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C-\\d+\\/\\d+"}}]}
 {"id": "crappr_volumnal_with_year_a", "description": "Criminal Appeal Reports (Volumnal Pre-1995)", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"}, {"TEXT": {"REGEX": "\\d+"}}, {"ORTH": "Cr"},{"IS_PUNCT": true},{"ORTH": "App"},{"IS_PUNCT": true}, {"ORTH": "R."}, {"LIKE_NUM": true}]}
 {"id": "crappr_annual", "description": "Criminal Appeal Reports (Annual Volumes Post-1995)", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"LIKE_NUM": true},{"ORTH": "Cr"},{"ORTH": "App"}, {"ORTH": "R"}, {"LIKE_NUM": true}]}
 {"id": "crappr_sentencing_annual", "description": "Criminal Appeal Reports (Sentencing) (Annual Volumes Post-1995)", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"}, {"LIKE_NUM": true},{"ORTH": "Cr"},{"ORTH": "App"}, {"ORTH": "R"},{"ORTH": "("},{"ORTH": "S"},{"ORTH": ")"}, {"LIKE_NUM": true}]}
@@ -188,9 +187,9 @@
 {"id": "rpc_a", "description": "Reports of Patents Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "R.P.C."},{"LIKE_NUM": true}]}
 {"id": "stc", "description": "Simon's Tax Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "STC"},{"LIKE_NUM": true}]}
 {"id": "taxcases", "description": "Appeal Cases (1875-1890) (ICLR)", "label": "CITATION", "pattern": [{"LIKE_NUM": true},{"ORTH": "TC"}, {"LIKE_NUM": true}]}
+{"id": "eu_c_case_a", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "C\\d+\\/\\d+"}}]}
 {"id": "eu_c_case_c", "description": "Court of Justice of the European Union (C-Case)", "label": "CITATION", "pattern": [{"ORTH": "case"},{"TEXT": {"REGEX": "C-\\d+\\/\\d+"}}]}
 {"id": "eu_t_case", "description": "Court of Justice of the European Union (T-Case)", "label": "CITATION", "pattern": [{"ORTH": "Case"},{"TEXT": {"REGEX": "T-\\d+\\/\\d+"}}]}
 {"id": "bcc", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "BCC"},{"LIKE_NUM": true}]}
 {"id": "bcc_a", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"},{"ORTH": "BCC"},{"LIKE_NUM": true}]}
 {"id": "bcc_b", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "["}, {"SHAPE": "dddd"}, {"ORTH": "]"},{"ORTH": "B.C.C."},{"LIKE_NUM": true}]}
-{"id": "bcc_c", "description": "British Company Cases", "label": "CITATION", "pattern": [{"ORTH": "("}, {"SHAPE": "dddd"}, {"ORTH": ")"},{"ORTH": "B.C.C."},{"LIKE_NUM": true}]}

--- a/tests/caselaw_extraction_tests/test_case_citations.py
+++ b/tests/caselaw_extraction_tests/test_case_citations.py
@@ -19,7 +19,6 @@ from database.db_connection import get_matched_rule
 from replacer.replacer import replacer_caselaw
 from utils.helper import load_patterns
 
-
 CORRECT_CITATIONS = [
     "random text goes here random text goes here **[2022] UKUT 177 (TCC)",
     "[2022] 1 Lloyd's Rep 123.",

--- a/tests/caselaw_extraction_tests/test_case_citations.py
+++ b/tests/caselaw_extraction_tests/test_case_citations.py
@@ -1,22 +1,23 @@
-import sys
-import unittest
-
-from spacy.lang.en import English
-
-sys.path.append("./")
-from caselaw_extraction.correction_strategies import apply_correction_strategy
-from database.db_connection import (
-    close_connection,
-    create_connection,
-    get_matched_rule,
-)
-from replacer.replacer import replacer_caselaw
-from utils.helper import load_patterns
-
 """
     Testing the matching of the citations based on the data found in the rules.
     These are independent unit tests.
 """
+
+import sys
+import unittest
+
+import pandas as pd
+import psycopg2
+import testing.postgresql
+from spacy.lang.en import English
+from sqlalchemy import create_engine
+
+from caselaw_extraction.correction_strategies import apply_correction_strategy
+from database.db_connection import get_matched_rule
+from replacer.replacer import replacer_caselaw
+from utils.helper import load_patterns
+
+sys.path.append("./")
 
 CORRECT_CITATIONS = [
     "random text goes here random text goes here **[2022] UKUT 177 (TCC)",
@@ -82,28 +83,29 @@ def mock_get_rules_total(db_conn):
     return number_of_rules
 
 
-# creating a global set up to avoid duplicating
-# logic normally handled in main.py
-def set_up():
-    nlp = English()
-    nlp.max_length = 1500000
-    nlp.add_pipe("entity_ruler").from_disk("rules/citation_patterns.jsonl")
-    # TODO: change this to a mock db?
-    db_conn = create_connection("tna", "editha.nemsic", "", "localhost", 5432)
-    load_patterns(db_conn)
-    return nlp, db_conn
-
-
-"""
+class TestCitationProcessor(unittest.TestCase):
+    """
     This class focuses on testing the Citation Processor, which gathers the results from the DB. This class primarily uses the mock_return_citation method.
     This includes testing incorrect or missing citations.
     This is relevant for the logic performed in main.py
-"""
+    """
 
-
-class TestCitationProcessor(unittest.TestCase):
     def setUp(self):
-        self.nlp, self.db_conn = set_up()
+        self.nlp = English()
+        self.nlp.max_length = 1500000
+        self.nlp.add_pipe("entity_ruler").from_disk("rules/citation_patterns.jsonl")
+
+        self.postgresql = testing.postgresql.Postgresql()
+        self.db_conn = psycopg2.connect(**self.postgresql.dsn())
+        engine = create_engine(self.postgresql.url())
+
+        manifest_df = pd.read_csv("rules/2022_04_08_Citation_Manifest.csv")
+        manifest_df.to_sql("manifest", engine, if_exists="append", index=False)
+
+        load_patterns(self.db_conn)
+
+    def tearDown(self):
+        self.postgresql.stop()
 
     # Handling extra characters around the citations to ensure that spacy handles it well
     def test_citation_matching(self):
@@ -232,22 +234,8 @@ class TestCitationProcessor(unittest.TestCase):
             ) = mock_return_citation(self.nlp, text, self.db_conn)
             assert is_canonical != True and is_canonical != False
 
-    def tearDown(self):
-        close_connection(self.db_conn)
-
-
-"""
-    This class focuses on testing the Citation Matcher, which includes verifying that correct citations are matched to ensure that the
-    DB is behaving as expected.
-    This also verifies that the year and numbers are extracted correctly is extracted from the citation as expected, this is relevant for
-    correct_strategies.py
-"""
-
 
 class TestCorrectionStrategy(unittest.TestCase):
-    def setUp(self):
-        self.nlp, self.db_conn = set_up()
-
     def test_correct_forms(self):
         citation_match = "1 ExD 123"
         citation_type = "PubNumAbbrNum"
@@ -256,7 +244,7 @@ class TestCorrectionStrategy(unittest.TestCase):
             citation_type, citation_match, canonical_form
         )
         assert corrected_citation == citation_match
-        assert year == "No Year"
+        assert year == ""
 
         citation_match = "[2025] EWHC 123 (TCC)"
         citation_type = "NCitYearAbbrNumDiv"
@@ -292,7 +280,7 @@ class TestCorrectionStrategy(unittest.TestCase):
             citation_type, citation_match, canonical_form
         )
         assert corrected_citation == citation_match
-        assert year == "No Year"
+        assert year == ""
 
     def test_incorrect_forms(self):
         citation_match = "[2022] P.N.L.R 123"
@@ -345,18 +333,11 @@ class TestCorrectionStrategy(unittest.TestCase):
         assert corrected_citation == "[2019] QB 456"
         assert year == "2019"
 
-    def tearDown(self):
-        close_connection(self.db_conn)
-
-
-"""
-    This class tests the replacement of the citations within the text itself. This comes from replacer.py
-"""
-
 
 class TestCitationReplacer(unittest.TestCase):
-    def setUp(self):
-        self.nlp, self.db_conn = set_up()
+    """
+    This class tests the replacement of the citations within the text itself. This comes from replacer.py
+    """
 
     def test_citation_replacer(self):
         citation_match = "[2025] 1 All E.R. 123"  # incorrect citation
@@ -370,11 +351,9 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref type="case" href="{}" isNeutral="{}" canonical="{}" year="{}">{}</ref>'.format(
+        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
-        print(replaced_entry)
-        print(replacement_string)
         assert replacement_string in replaced_entry
 
         citation_match = "[2022] UKET 789123_2012"
@@ -386,7 +365,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref type="case" href="{}" isNeutral="{}" canonical="{}" year="{}">{}</ref>'.format(
+        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -400,7 +379,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref type="case" href="{}" isNeutral="{}" canonical="{}" year="{}">{}</ref>'.format(
+        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -414,7 +393,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref type="case" href="{}" isNeutral="{}" canonical="{}" year="{}">{}</ref>'.format(
+        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -428,13 +407,10 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref type="case" href="{}" isNeutral="{}" canonical="{}" year="{}">{}</ref>'.format(
+        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
-
-    def tearDown(self):
-        close_connection(self.db_conn)
 
 
 if __name__ == "__main__":

--- a/tests/caselaw_extraction_tests/test_case_citations.py
+++ b/tests/caselaw_extraction_tests/test_case_citations.py
@@ -12,12 +12,13 @@ import testing.postgresql
 from spacy.lang.en import English
 from sqlalchemy import create_engine
 
+sys.path.append("./")
+
 from caselaw_extraction.correction_strategies import apply_correction_strategy
 from database.db_connection import get_matched_rule
 from replacer.replacer import replacer_caselaw
 from utils.helper import load_patterns
 
-sys.path.append("./")
 
 CORRECT_CITATIONS = [
     "random text goes here random text goes here **[2022] UKUT 177 (TCC)",
@@ -101,8 +102,6 @@ class TestCitationProcessor(unittest.TestCase):
 
         manifest_df = pd.read_csv("rules/2022_04_08_Citation_Manifest.csv")
         manifest_df.to_sql("manifest", engine, if_exists="append", index=False)
-
-        load_patterns(self.db_conn)
 
     def tearDown(self):
         self.postgresql.stop()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,8 @@ spacy==3.2.2
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pandas==1.4.1
 psycopg2==2.9.5
-bs4==4.11.2
+beautifulsoup4==4.11.2
 spaczz==0.5.4
 lxml==4.9.2
+testing.postgresql==1.3.0
+sqlalchemy==2.0.4


### PR DESCRIPTION
Here we make the tests use testing.postgres package instead of an actual local postgres db. Also simplify tests that do not need a db to not use one.

Thought about a way to avoid needing a db for the unit tests but it seems like the remaining tests with db access make sense to have access to a db.

There will be one more PR to fix some `filter_matches` tests in `tests/abbreviation_extraction_tests/test_abbreviations.py` which have issues for short form abbreviations which include lower case "the" as a prefix, e.g. "the VAT Act". After that all tests will be passing. Then will make a final PR to make the tests run in CI.