### PR TITLE
Explicitly set aurora version to 11.17

### DIFF
--- a/modules/data/rds.tf
+++ b/modules/data/rds.tf
@@ -5,7 +5,7 @@ module "metadata-db" {
   name = "${local.name}-metadata-db-${local.environment}"
 
   engine         = "aurora-postgresql"
-  engine_version = "13"
+  engine_version = "11.17"
   instance_type  = "db.t3.medium"
 
   vpc_id                = var.vpc_id


### PR DESCRIPTION
Trying to fix this error in deploy:

```
Error: Failed to modify RDS Cluster (tna-metadata-db-staging): InvalidParameterCombination: Cannot upgrade aurora-postgresql from 11.17 to 11.13
	status code: 400, request id: bd751f27-e503-4bbf-bf0a-7d677a311401

  with module.data.module.metadata-db.aws_rds_cluster.this[0],
  on .terraform/modules/data.metadata-db/main.tf line 50, in resource "aws_rds_cluster" "this":
  50: resource "aws_rds_cluster" "this" {
  
```

Upgrading to 13 gave the same error with "Cannot upgrade aurora-postgresql from 11.17 to 13.7"