### PR TITLE
Fix the tidied up deploy workflow after realising error once merged to main

### DIFF
--- a/.github/workflows/cd_deploy_staging_then_prod.yml
+++ b/.github/workflows/cd_deploy_staging_then_prod.yml
@@ -1,4 +1,4 @@
-name: Apply Staging then Prod
+name: Deploy to Staging then Prod
 
 on:
   push:
@@ -16,8 +16,8 @@ defaults:
 
 jobs:
   staging_apply:
-    name: Apply Staging Build
-    uses: ./.github/workflows/build.yml
+    name: Deploy Staging Build
+    uses: ./.github/workflows/deploy_single_environment.yml
     secrets:
       account_id: ${{ secrets.STAGING_ACCOUNT_ID }}
       workspace: tna-staging
@@ -25,8 +25,8 @@ jobs:
 
 
   prod_apply:
-    name: Apply Production Build
-    uses: ./.github/workflows/build.yml
+    name: Deploy Production Build
+    uses: ./.github/workflows/deploy_single_environment.yml
     needs: staging_apply
     secrets:
       account_id: ${{ secrets.PROD_ACCOUNT_ID }}


### PR DESCRIPTION


There was a bug in the deployment CICD workflow in PR: ta-enrichment-service/pull/165 which was only noticed when run on main.

This fixes it.