### PR TITLE
Bug/refactor oblique references/455

### DIFF
--- a/oblique_references/oblique_references.py
+++ b/oblique_references/oblique_references.py
@@ -1,15 +1,22 @@
 """
 @author: editha.nemsic
-This code handles the link of oblique references (i.e 'the Act' or 'the 1977 Act'). This is done in the following way:
-1. We use the previously enriched judgment and identify where there are legislation xrefs in the judgment body.
-2. We search for 'T(t)he/T(t)his/T(t)hat Act' and 'T(t)he/T(t)his/T(t)hat [dddd] Act' references in the judgment text.
-3. If the matched oblique reference does not contain a year, we use the location of the oblique reference and 'legislation' reference
-to find which legislation the oblique reference is closest to, and then link to that legislation.
-4. If the matched oblique reference contains a year, we search for the matched 'legislation' (found in 1.) that corresponds to that year
-and then link to that legislation.
-5. We build a replacement string that wraps the detected oblique reference into a <ref> element with the link and canonical form of the linked legislation as attributes.
+This code handles the link of oblique references (i.e 'the Act' or 'the 1977 Act'). 
 
-The pipeline returns a dictionary containing the detected oblique reference, its position and the replacement string.
+This is done in the following way:
+1. We use the previously enriched judgment and identify where there are legislation
+    xrefs in the judgment body.
+2. We search for 'T(t)he/T(t)his/T(t)hat Act' and 'T(t)he/T(t)his/T(t)hat [dddd] Act'
+    references in the judgment text.
+3. If the matched oblique reference does not contain a year, we use the location of the
+    oblique reference and 'legislation' reference to find which legislation the oblique
+    reference is closest to, and then link to that legislation.
+4. If the matched oblique reference contains a year, we search for the matched
+    'legislation' (found in 1.) that corresponds to that year and then link to that legislation.
+5. We build a replacement string that wraps the detected oblique reference into a <ref>
+    element with the link and canonical form of the linked legislation as attributes.
+
+The pipeline returns a dictionary containing the detected oblique reference, its
+    position and the replacement string.
 """
 
 import re
@@ -43,7 +50,8 @@ def create_legislation_dict(
 ) -> List[Dict[str, Any]]:
     """
     Create a dictionary containing metadata of the detected 'legislation' reference
-    :param leg_references: list of legislation references found in the judgment and their location
+    :param leg_references: list of legislation references found in the judgment and
+        their location
     :returns: list of legislation dictionaries
     """
     legislation_dicts = []
@@ -137,7 +145,10 @@ def create_section_ref_tag(replacement_dict: LegislationDict, match: str) -> str
     """
     canonical = replacement_dict["canonical"]
     href = replacement_dict["href"]
-    oblique_ref = f'<ref href="{href}" uk:canonical="{canonical}" uk:type="legislation" uk:origin="TNA">{match.strip()}</ref>'
+    oblique_ref = (
+        f'<ref href="{href}" uk:canonical="{canonical}" '
+        f'uk:type="legislation" uk:origin="TNA">{match.strip()}</ref>'
+    )
 
     return oblique_ref
 
@@ -178,7 +189,8 @@ def oblique_pipeline(file_content: str) -> List[Dict]:
     """
     Create replacement string for detected oblique reference
     :param file_content: original judgment file content
-    :returns: list of dictionaries containing detected oblique references and replacement strings
+    :returns: list of dictionaries containing detected oblique
+        references and replacement strings
     """
     soup = BeautifulSoup(file_content, "xml")
     paragraphs = soup.find_all("p")

--- a/oblique_references/oblique_references.py
+++ b/oblique_references/oblique_references.py
@@ -66,6 +66,7 @@ def create_legislation_dict(
 
     return legislation_dicts
 
+
 def _get_legislation_year(legislation_name):
     if not legislation_name:
         return ""
@@ -76,7 +77,7 @@ def _get_legislation_year(legislation_name):
     if not legislation_year:
         return ""
     return legislation_year
-    
+
 
 def match_numbered_act(
     detected_numbered_act: DetectedReference, legislation_dicts: List[LegislationDict]
@@ -122,7 +123,7 @@ def match_act(
             ref for ref in eligble_references if ref["pos"][0] == correct_pos
         ][0]
     else:
-        correct_ref = []
+        correct_ref = {}
 
     return correct_ref
 

--- a/oblique_references/oblique_references.py
+++ b/oblique_references/oblique_references.py
@@ -190,7 +190,7 @@ def oblique_pipeline(file_content: str) -> List[Dict]:
     detected_numbered_acts = detect_reference(text, "numbered_act")
     detected_acts = detect_reference(text, "act")
 
-    replacements: List = []
+    replacements: List[Dict] = []
     replacements = get_replacements(
         detected_acts, legislation_dicts, False, replacements
     )

--- a/oblique_references/oblique_references.py
+++ b/oblique_references/oblique_references.py
@@ -12,9 +12,8 @@ and then link to that legislation.
 The pipeline returns a dictionary containing the detected oblique reference, its position and the replacement string.
 """
 
-
-import os
 import re
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from bs4 import BeautifulSoup
 
@@ -24,8 +23,11 @@ patterns = {
     "act": r"(the|this|that|The|This|That)\s(Act)",
 }
 
+DetectedReference = Tuple[Tuple[int, int], str]
+LegislationDict = Dict[str, Any]
 
-def detect_reference(text, etype):
+
+def detect_reference(text: str, etype: str) -> List[DetectedReference]:
     """
     Detect legislation and oblique references.
     :param text: text to be searched for references
@@ -33,11 +35,12 @@ def detect_reference(text, etype):
     :returns: list of detected references
     """
     references = [(m.span(), m.group()) for m in re.finditer(patterns[etype], text)]
-
     return references
 
 
-def create_legislation_dict(leg_references):
+def create_legislation_dict(
+    legislation_references: List[DetectedReference],
+) -> List[Dict[str, Any]]:
     """
     Create a dictionary containing metadata of the detected 'legislation' reference
     :param leg_references: list of legislation references found in the judgment and their location
@@ -45,38 +48,59 @@ def create_legislation_dict(leg_references):
     """
     legislation_dicts = []
 
-    for leg_ref in leg_references:
-        legislation_dict = {}
-        soup = BeautifulSoup(leg_ref[1], "xml")
-        ref = soup.find("ref")
-        leg_name = ref.text
-        leg_year = re.search("\d{4}", leg_name).group(0)
-        href = ref["href"]
-        canonical = ref["canonical"]
-        legislation_dict["pos"] = leg_ref[0]
+    for legislation_reference in legislation_references:
+        legislation_dict: Dict[str, Any] = {}
+        soup = BeautifulSoup(legislation_reference[1], "xml")
+        ref = soup.ref
+        if not ref:
+            continue
+        leg_name = ref.text if not None else ""
+
+        legislation_dict["pos"] = legislation_reference[0]
         legislation_dict["detected_leg"] = leg_name
-        legislation_dict["href"] = href
-        legislation_dict["canonical"] = canonical
-        legislation_dict["year"] = leg_year
+        legislation_dict["href"] = ref["href"]
+        legislation_dict["canonical"] = ref.get("canonical")
+        legislation_dict["year"] = _get_legislation_year(leg_name)
+
         legislation_dicts.append(legislation_dict)
 
     return legislation_dicts
 
+def _get_legislation_year(legislation_name):
+    if not legislation_name:
+        return ""
+    legislation_year_search = re.search("\d{4}", legislation_name)
+    if not legislation_year_search:
+        return ""
+    legislation_year = legislation_year_search.group(0)
+    if not legislation_year:
+        return ""
+    return legislation_year
+    
 
-def match_numbered_act(detected_numbered_act, legislation_dicts):
+def match_numbered_act(
+    detected_numbered_act: DetectedReference, legislation_dicts: List[LegislationDict]
+) -> LegislationDict:
     """
     Match oblique references containing a year
     :param detected_numbered_act: detected oblique reference
     :param legislation_dicts: list of legislation dictionaries
     :returns: matched legislation dictionary
     """
-    act_year = re.search("\d{4}", detected_numbered_act[1]).group(0)
+    act_year_match = re.search("\d{4}", detected_numbered_act[1])
+    if not act_year_match:
+        return {}
+
+    act_year = act_year_match.group(0)
     for leg_dict in legislation_dicts:
         if leg_dict["year"] == act_year:
             return leg_dict
+    return {}
 
 
-def match_act(detected_act, legislation_dicts):
+def match_act(
+    detected_act: DetectedReference, legislation_dicts: List[LegislationDict]
+) -> LegislationDict:
     """
     Match oblique references without a year
     :param detected_act: detected oblique reference
@@ -103,7 +127,7 @@ def match_act(detected_act, legislation_dicts):
     return correct_ref
 
 
-def create_section_ref_tag(replacement_dict, match):
+def create_section_ref_tag(replacement_dict: LegislationDict, match: str) -> str:
     """
     Create replacement string for detected oblique reference
     :param replacement_dict: legislation dictionary for replacement
@@ -117,7 +141,12 @@ def create_section_ref_tag(replacement_dict, match):
     return oblique_ref
 
 
-def get_replacements(detected_acts, legislation_dicts, numbered_act, replacements):
+def get_replacements(
+    detected_acts: List[DetectedReference],
+    legislation_dicts: List[Dict],
+    numbered_act: bool,
+    replacements: List[Dict],
+) -> List[Dict[str, Union[str, int]]]:
     """
     Create replacement string for detected oblique reference
     :param detected_acts: detected oblique references
@@ -127,7 +156,7 @@ def get_replacements(detected_acts, legislation_dicts, numbered_act, replacement
     :returns: list of replacements
     """
     for detected_act in detected_acts:
-        replacement_dict = {}
+        replacement_dict: Dict[str, Union[str, int]] = {}
         match = detected_act[1]
         if numbered_act:
             matched_replacement = match_numbered_act(detected_act, legislation_dicts)
@@ -144,15 +173,15 @@ def get_replacements(detected_acts, legislation_dicts, numbered_act, replacement
     return replacements
 
 
-def oblique_pipeline(file_data):
+def oblique_pipeline(file_content: str) -> List[Dict]:
     """
     Create replacement string for detected oblique reference
-    :param file_data: file content
+    :param file_content: original judgment file content
     :returns: list of dictionaries containing detected oblique references and replacement strings
     """
-    soup = BeautifulSoup(file_data, "xml")
-    text = soup.find_all("p")
-    text = "".join([str(p) for p in text])
+    soup = BeautifulSoup(file_content, "xml")
+    paragraphs = soup.find_all("p")
+    text = "".join([str(p) for p in paragraphs])
 
     detected_leg = detect_reference(text, "legislation")
     legislation_dicts = create_legislation_dict(detected_leg)
@@ -160,7 +189,7 @@ def oblique_pipeline(file_data):
     detected_numbered_acts = detect_reference(text, "numbered_act")
     detected_acts = detect_reference(text, "act")
 
-    replacements = []
+    replacements: List = []
     replacements = get_replacements(
         detected_acts, legislation_dicts, False, replacements
     )


### PR DESCRIPTION
Second preparatory PR for fixing https://trello.com/c/Xvk7Zg67/455-enrichment-duplication-bug

This PR makes the following changes to `oblique_references/oblique_references.py` which is the main file that gets adjusted in the upcoming fix for the bug:

- Added typehints to all functions
- Fixed all issues mypy had with the file
- Fixed an edge case where we were returning empty list instead of empty dict
- Fixed long lines

I installed

```
mypy==1.1.1
types-beautifulsoup4==1.1.11.12
```
locally to get mypy to run on the file. I also had to delete the `__init__.py` file in the root directory for it to run as it didnt like the non-snakecase project name `ds-caselaw-data-enrichment-service`.

---------------------------------------------------------

---- Side mypy and dev dependency discussion -----

I haven't yet added mypy to any requirements file / or to the CICD as I havent decided where is best for it.

Since this repo houses various lambda functions, they all have their own `requirements.txt` file.

The `tests` folder even has its own `requirements.txt` and this is what I have installed to get the tests running locally to this is where I added the above to get mypy working.

black and isort however currently aren't in any `requirements.txt` file and the readme just says to install them when needed and thats what is done in CICD - they are installed manually.

Still thinking about whether continuing with the isort/black pattern is best, or whether adding them all to a `requirements.txt` file - maybe the tests one - is best. It may be that we reorganise the test structure and have a CI job for each individual lambda function - that way we can specify one requirements.txt and specify dev dependencies and I feel that way the repo will remain more organised.

Whatever the result of this discussion is, it would be done in a separate PR

---------------------------------------------------------