### PR TITLE
Add debugging section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Situations when you may want to debug an enrichment run:
 
 The main ways we have to debug are to look at `AWS` [logs](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups) for `lambda` functions and data stored in [s3 buckets](https://s3.console.aws.amazon.com/s3/buckets?region=eu-west-2) but we need appropriate information to find these in AWS first.
 
+You will need access to for the staging or production Enrichment AWS space as appropriate to follow these debugging tips. If not, you could skip most of this and attempt at recreating a local test of a lambda function you think might have a problem like in [Recreate and debug](#recreate-and-debug)
+
 ### Getting information to investigate in AWS
 
 #### Find judgment name with failed lambda time

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Situations when you may want to debug an enrichment run:
 - a document we expect to have been enriched, has not been enriched as expected.
 - an AWS error alert for a lambda function has been raised to us (probably through email notification subscription)
 
-The main ways we have to debug are to look at logs for `lambda` functions and data stored in `s3` buckets but we need appropriate information to find these in AWS first.
+The main ways we have to debug are to look at `AWS` [logs](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups) for `lambda` functions and data stored in [s3 buckets](https://s3.console.aws.amazon.com/s3/buckets?region=eu-west-2) but we need appropriate information to find these in AWS first.
 
 ### Getting information to investigate in AWS
 
@@ -211,14 +211,14 @@ The main ways we have to debug are to look at logs for `lambda` functions and da
 
 #### Look at lambda logs
 
-We can access lambda function has a `log group` in which we can access different logs for different runs of the lambda.
+Each lambda function has a [log group](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups) in which we can access different logs for different runs of the lambda.
 
-1. We can find the logs for a parituclar lambda at a particular time by filtering the logs in that lambda's log group around the time we know the lambda run we care about was triggered.
+1. We can find the logs for a particular lambda at a particular time by filtering the logs in that lambda's log group around the time we know the lambda run we care about was triggered.
 2. Then we can find any relevant information from the logs to use for
   
 #### Look at s3 buckets
 
-At each stage of enrichment process we store the partially enriched xml back to an `s3` bucket as shown in `docs/img/architecture.png`.
+At each stage of enrichment process we store the partially enriched xml back to an [s3 bucket](https://s3.console.aws.amazon.com/s3/buckets?region=eu-west-2) as shown in `docs/img/architecture.png`.
 
 1. We can download the xml from each stage for the judgment by going to each s3 bucket in the AWS Enrichment space and searching for the judgment name.
 1. We can compare sequential stages of enriched xml for the judgment to attempt to determine where our issue may have arisen.

--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ Each lambda function has a [log group](https://eu-west-2.console.aws.amazon.com/
 #### Look at s3 buckets
 
 At each stage of enrichment process we store the partially enriched xml back to an [s3 bucket](https://s3.console.aws.amazon.com/s3/buckets?region=eu-west-2) as shown in `docs/img/architecture.png`.
+You can find all the s3 bucket names where they are defined in `modules/lambda_s3/bucket.tf` and can find all relationships between buckets and lambdas in `modules/lambda_s3/lambda.tf`.
 
 1. We can download the xml from each stage for the judgment by going to each s3 bucket in the AWS Enrichment space and searching for the judgment name.
-1. We can compare sequential stages of enriched xml for the judgment to attempt to determine where our issue may have arisen.
+2. We can compare sequential stages of enriched xml for the judgment to attempt to determine where our issue may have arisen.
    - e.g. if we can see that between enrichment stage 1 completing and enrichment stage 2 completing something odd happened to the xml we can focus on the lambda function that is called in between, here the `oblique_reference_replacer` lambda.
 
 ### Recreate and debug


### PR DESCRIPTION
https://trello.com/c/tDM43BiC/615-add-documentation-for-debugging-enrichment-pipeline-bugs

I have worked on a couple of the first enrichment bugs since handover and have come up with a good debugging method for failed enrichment.

This PR adds documentation for others to debug enrichment more easily 