### PR TITLE
Fix broken import due to replacer_pipeline move

### DIFF
--- a/src/lambdas/make_replacements/index.py
+++ b/src/lambdas/make_replacements/index.py
@@ -181,7 +181,7 @@ def replace_text_content(file_content, replacements_content):
     LOGGER.info("Replacement caselaw")
     print(replacement_tuples_case)
 
-    from replacer.replacer import replacer_pipeline
+    from replacer.replacer_pipeline import replacer_pipeline
 
     file_data_enriched = replacer_pipeline(
         file_content,


### PR DESCRIPTION
Fix broken import due to replacer_pipeline move

Noticed that production was broken after https://github.com/nationalarchives/ds-caselaw-data-enrichment-service/pull/190 due to the error message I received for a borken judgment at 1pm.

This fixes that.

At some point we should add pylint into CI to catch things like this.

And we need to complete adding integration tests for all lambda functions to catch other bugs too! (already have a ticket for this in the sprint)