### PR TITLE
Bug/dont catch lambda errors/640

### DIFF
--- a/src/lambdas/update_legislation_table/index.py
+++ b/src/lambdas/update_legislation_table/index.py
@@ -176,5 +176,6 @@ def handler(event, context):
         engine.dispose()
         LOGGER.info("Legislation updated")
 
-    except (Exception, Error) as error:
-        LOGGER.error("Error while connecting to PostgreSQL: %s", error)
+    except Exception as exception:
+        LOGGER.error("Exception: %s", exception)
+        raise

--- a/src/lambdas/update_rules_processor/index.py
+++ b/src/lambdas/update_rules_processor/index.py
@@ -175,7 +175,7 @@ def lambda_handler(event, context):
         except AssertionError:
             LOGGER.error("Exception: Manifest test failed")
             raise
-        
+
         try:
             # write new jsonl file
             new_patterns_file = write_patterns_file(df["pattern"].to_list())


### PR DESCRIPTION
We were previously catching all `Exception`s in `update_legislation_table` and `update_rules_processor`.

We noticed this when creating https://trello.com/c/RTIrUXGl/640-enrichment-legislation-table-not-been-updated-in-ages
since this `update_legislation_table` was erroring and showing so in the logs but the lambda function run was not failing as we did not reraise the exception after catching and logging like we do in all other lambda handler functions.

PR:
- Made sure to reraise caught exceptions in `update_legislation_table` and `update_rules_processor`
- Remove misleading postgres related info in exception
- Moved around some try except blocks in `update_rules_processor`