### PR TITLE
Update legislation update lambda to set year of legislations in db

### DIFF
--- a/src/lambdas/update_legislation_table/index.py
+++ b/src/lambdas/update_legislation_table/index.py
@@ -9,7 +9,6 @@ from io import BytesIO
 
 import boto3
 import pandas as pd
-from psycopg2 import Error
 from SPARQLWrapper import CSV, SPARQLWrapper
 from sqlalchemy import create_engine
 
@@ -114,7 +113,7 @@ def get_leg_update(sparql_username, sparql_password, days=7):
                 prefix sd: <http://www.w3.org/ns/sparql-service-description#>
                 prefix prov: <http://www.w3.org/ns/prov#>
                 prefix leg: <http://www.legislation.gov.uk/def/legislation/>
-                select distinct ?ref  ?title ?ref_version ?shorttitle ?citation ?acronymcitation
+                select distinct ?ref  ?title ?ref_version ?shorttitle ?citation ?acronymcitation ?year
                 where {
                    ?activity prov:endedAtTime ?actTime .
                    ?graph prov:wasInfluencedBy ?activity .
@@ -124,9 +123,10 @@ def get_leg_update(sparql_username, sparql_password, days=7):
                    graph ?graph { ?ref a leg:Legislation; a leg:UnitedKingdomPublicGeneralAct ;
                                         leg:title ?title ;
                                         leg:interpretation ?version .
-                                   OPTIONAL { ?ref leg:citation ?citation  } .
-                                   OPTIONAL {?ref leg:acronymCitation ?acronymcitation} .
-                                   OPTIONAL {?ref_version   leg:shortTitle ?shorttitle} .}
+                                        OPTIONAL {?ref leg:citation ?citation} .
+                                        OPTIONAL {?ref leg:acronymCitation ?acronymcitation} .
+                                        OPTIONAL {?ref leg:year ?year} .
+                                        OPTIONAL {?ref_version   leg:shortTitle ?shorttitle} .}
                    FILTER(str(?actTime) > "%s")
                 }
                 """


### PR DESCRIPTION
**Background:**

For whatever reason, there was no code in the codebase setting the `year` column in the `ukpga_lookup` table which exists in production and is accessed in the lambda for enriching legislation in a document.

When it isn't there, those legislations are ignored.

From 2021 and earlier, apart from the final legislation of that year `Armed Forces Act 2021` had the year populated in the production db, however, everything from 2022 onwards was not.

I have manually fixed that on the production server.


**Purpose of this PR:**
- makes sure all newly synced legislations (the lambda runs weekly to sync the db up with the legislation in the legislation service from the past week) include year.

Note: the legislation before 2018 don't seem to have the year field in the legislation service, so for those this new code wouldn't work and we would have to actually parse the year from the other fields but it seems like everything since then does, so we can assume it is fine from now on.

Note 2: It might be worth us reconsidering whether it is worth us having to manually sync the db up with legislation service rather than just making calls to legislation when needed but not for this ticket.