### PR TITLE
Simplify db env vars

### DIFF
--- a/src/database/db_connection.py
+++ b/src/database/db_connection.py
@@ -26,7 +26,6 @@ def create_connection(db, user, password, host, port):
     except (Exception, psycopg2.DatabaseError) as error:
         print(error)
         raise
-    # return conn
 
 
 def get_manifest_row(conn, rule_id):

--- a/src/database/db_connection.py
+++ b/src/database/db_connection.py
@@ -5,7 +5,7 @@ import pandas as pd
 import psycopg2
 
 
-def create_connection(db, user, password, host, port):
+def create_connection(db, user, password, host, port) -> psycopg2.extensions.connection:
     """
     Connect to the PostgreSQL database server
     :param db

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -2,7 +2,6 @@
 
 import datetime
 import logging
-import os
 import urllib.parse
 
 import boto3
@@ -12,23 +11,10 @@ from legislation_provisions_extraction.legislation_provisions import (
     provisions_pipeline,
 )
 from replacer.second_stage_replacer import replace_references_by_paragraph
+from utils.environment_helpers import validate_env_variable
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 def upload_contents(source_key, output_file_content):

--- a/src/lambdas/determine_oblique_references/index.py
+++ b/src/lambdas/determine_oblique_references/index.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import urllib.parse
 
 import boto3
@@ -9,23 +8,10 @@ import boto3
 from oblique_references.enrich_oblique_references import (
     enrich_oblique_references,
 )
+from utils.environment_helpers import validate_env_variable
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 def upload_contents(source_key, output_file_content):

--- a/src/lambdas/determine_replacements_abbreviations/index.py
+++ b/src/lambdas/determine_replacements_abbreviations/index.py
@@ -2,27 +2,14 @@
 
 import json
 import logging
-import os
 
 import boto3
 import spacy
 
+from utils.environment_helpers import validate_env_variable
+
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    LOGGER.debug(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 # isolating processing from event unpacking for portability and testing

--- a/src/lambdas/determine_replacements_caselaw/index.py
+++ b/src/lambdas/determine_replacements_caselaw/index.py
@@ -1,83 +1,18 @@
 #!/usr/bin/env python3
 
-import base64
 import json
 import logging
-import os
 import urllib.parse
 
 import boto3
 import spacy
 
 from database import db_connection
+from utils.environment_helpers import validate_env_variable
+from utils.initialise_db import init_db_connection
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    LOGGER.debug(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
-
-
-############################################
-# CLASS HELPERS
-############################################
-class getLoginSecrets:
-    def get_secret(self, aws_secret_name, aws_region_name):
-        """
-        Get login secrets for database access
-        """
-        secret_name = aws_secret_name
-        region_name = aws_region_name
-
-        # Create a Secrets Manager client
-        session = boto3.session.Session()
-        client = session.client(service_name="secretsmanager", region_name=region_name)
-
-        try:
-            LOGGER.info(" about to get_secret_value_response")
-            get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-            LOGGER.info("got_secret_value_response")
-
-            if "SecretString" in get_secret_value_response:
-                secret = get_secret_value_response["SecretString"]
-                LOGGER.info("got SecretString")
-            else:
-                LOGGER.info("not SecretString")
-                decoded_binary_secret = base64.b64decode(
-                    get_secret_value_response["SecretBinary"]
-                )
-                secret = decoded_binary_secret
-            LOGGER.info("here")
-            return secret
-        except Exception as exception:
-            LOGGER.error("Exception: %s", exception)
-            raise
-
-
-############################################
-# - INSTANTIATE CLASS HELPERS
-# - GET ENV VARIABLES
-############################################
-database_name = validate_env_variable("DATABASE_NAME")
-table_name = validate_env_variable("TABLE_NAME")
-username = validate_env_variable("USERNAME")
-port = validate_env_variable("PORT")
-host = validate_env_variable("HOSTNAME")
-aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
-aws_region_name = validate_env_variable("REGION_NAME")
-
-get_secret = getLoginSecrets()
 
 
 # isolating processing from event unpacking for portability and testing
@@ -188,17 +123,6 @@ def init_NLP(rules_content):
     return nlp
 
 
-def init_DB():
-    """
-    Establish database connection
-    """
-    password = get_secret.get_secret(aws_secret_name, aws_region_name)
-    db_conn = db_connection.create_connection(
-        database_name, username, password, host, port
-    )
-    return db_conn
-
-
 def close_connection(db_conn):
     """
     Close the database connection
@@ -211,7 +135,7 @@ def determine_replacements(file_content, rules_content):
     Fetch caselaw replacements from database
     """
     # connect to the database
-    db_conn = init_DB()
+    db_conn = init_db_connection()
 
     # setup the spacy pipeline
     nlp = init_NLP(rules_content)

--- a/src/lambdas/extract_judgement_contents/index.py
+++ b/src/lambdas/extract_judgement_contents/index.py
@@ -6,24 +6,11 @@ import urllib.parse
 
 import boto3
 
+from utils.environment_helpers import validate_env_variable
 from utils.helper import parse_file
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 def process_event(sqs_rec):

--- a/src/lambdas/fetch_xml/index.py
+++ b/src/lambdas/fetch_xml/index.py
@@ -1,27 +1,14 @@
 # Replace this file with functional code rather than one that just lists the S3 buckets.
 import json
 import logging
-import os
 
 import boto3
 import urllib3
 
+from utils.environment_helpers import validate_env_variable
+
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 ############################################

--- a/src/lambdas/update_rules_processor/index.py
+++ b/src/lambdas/update_rules_processor/index.py
@@ -1,88 +1,18 @@
 #!env/bin/python
 
-import base64
 import json
 import logging
-import os
 import urllib.parse
 from io import StringIO
 
 import boto3
 import pandas as pd
 import spacy
-from psycopg2 import Error
-from sqlalchemy import create_engine
+
+from utils.initialise_db import init_db_engine
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
-
-
-############################################
-# CLASS HELPERS
-############################################
-class getLoginSecrets:
-    def get_secret(self, aws_secret_name, aws_region_name):
-        """
-        Get login secrets for database access
-        """
-        secret_name = aws_secret_name
-        region_name = aws_region_name
-
-        # Create a Secrets Manager client
-        session = boto3.session.Session()
-        client = session.client(service_name="secretsmanager", region_name=region_name)
-
-        try:
-            LOGGER.info(" about to get_secret_value_response")
-            get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-            LOGGER.info("got_secret_value_response")
-
-            # Decrypts secret using the associated KMS CMK.
-            # Depending on whether the secret is a string or binary, one of these fields will be populated.
-            if "SecretString" in get_secret_value_response:
-                secret = get_secret_value_response["SecretString"]
-                LOGGER.info("got SecretString")
-            else:
-                LOGGER.info("not SecretString")
-                decoded_binary_secret = base64.b64decode(
-                    get_secret_value_response["SecretBinary"]
-                )
-                secret = decoded_binary_secret
-            LOGGER.info("here")
-            return secret
-
-        except Exception as exception:
-            LOGGER.error("Exception: %s", exception)
-            raise
-
-
-############################################
-# - INSTANTIATE CLASS HELPERS
-# - GET ENV VARIABLES
-############################################
-database_name = validate_env_variable("DATABASE_NAME")
-table_name = validate_env_variable("TABLE_NAME")
-username = validate_env_variable("USERNAME")
-port = validate_env_variable("PORT")
-host = validate_env_variable("HOSTNAME")
-aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
-aws_region_name = validate_env_variable("REGION_NAME")
-
-get_secret = getLoginSecrets()
 
 
 def write_patterns_file(patterns_list):
@@ -147,9 +77,6 @@ def lambda_handler(event, context):
     """
     LOGGER.info("Updating case law detection rules")
 
-    # get password for database
-    password = get_secret.get_secret(aws_secret_name, aws_region_name)
-
     # read CSV file from rules bucket
     s3 = boto3.client("s3")
     source_bucket = event["Records"][0]["s3"]["bucket"]["name"]
@@ -184,9 +111,7 @@ def lambda_handler(event, context):
             )
 
             # connect to database
-            engine = create_engine(
-                f"postgresql://{username}:{password}@{host}:{port}/{database_name}"
-            )
+            engine = init_db_engine()
             LOGGER.info("Engine created")
 
             # push rules to database --> if_exists="replace" as we're pushing full ruleset

--- a/src/lambdas/xml_validate/index.py
+++ b/src/lambdas/xml_validate/index.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import urllib.parse
 from distutils.util import strtobool
 from io import BytesIO
@@ -10,24 +9,12 @@ from io import BytesIO
 import boto3
 from lxml import etree
 
+from utils.environment_helpers import validate_env_variable
+
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 client = boto3.client("ssm")
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 def process_event(sqs_rec):

--- a/src/utils/environment_helpers.py
+++ b/src/utils/environment_helpers.py
@@ -25,9 +25,11 @@ def validate_env_variable(env_var_name):
 
 
 def get_database_password():
-    password = validate_env_variable("DATABASE_PASSWORD")
-    if password is not None:
+    try:
+        password = validate_env_variable("DATABASE_PASSWORD")
         return password
+    except Exception:
+        pass
     aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
     aws_region_name = validate_env_variable("REGION_NAME")
     return _get_aws_secret(aws_secret_name, aws_region_name)

--- a/src/utils/environment_helpers.py
+++ b/src/utils/environment_helpers.py
@@ -24,13 +24,7 @@ def validate_env_variable(env_var_name):
     return env_variable
 
 
-def get_database_password():
-    aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
-    aws_region_name = validate_env_variable("REGION_NAME")
-    return _get_aws_secret(aws_secret_name, aws_region_name)
-
-
-def _get_aws_secret(aws_secret_name, aws_region_name):
+def get_aws_secret(aws_secret_name, aws_region_name):
     """
     Get aws secret
     """

--- a/src/utils/environment_helpers.py
+++ b/src/utils/environment_helpers.py
@@ -1,0 +1,68 @@
+"""This module contains functions to read in environment variables"""
+
+import base64
+import logging
+import os
+
+import boto3
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+
+def validate_env_variable(env_var_name):
+    print(f"Getting the value of the environment variable: {env_var_name}")
+
+    try:
+        env_variable = os.environ[env_var_name]
+    except KeyError:
+        raise Exception(f"Please, set environment variable {env_var_name}")
+
+    if not env_variable:
+        raise Exception(f"Please, provide environment variable {env_var_name}")
+
+    return env_variable
+
+
+def get_database_password():
+    password = validate_env_variable("DATABASE_PASSWORD")
+    if password is not None:
+        return password
+    aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
+    aws_region_name = validate_env_variable("REGION_NAME")
+    return _get_aws_secret(aws_secret_name, aws_region_name)
+
+
+def _get_aws_secret(aws_secret_name, aws_region_name):
+    """
+    Get aws secret
+    """
+    secret_name = aws_secret_name
+    region_name = aws_region_name
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=region_name)
+
+    try:
+        LOGGER.info(" about to get_secret_value_response")
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+        LOGGER.info("got_secret_value_response")
+
+        # Decrypts secret using the associated KMS CMK.
+        # Depending on whether the secret is a string or binary, one of these fields will be populated.
+        if "SecretString" in get_secret_value_response:
+            secret = get_secret_value_response["SecretString"]
+            LOGGER.info("got SecretString")
+        else:
+            LOGGER.info("not SecretString")
+            decoded_binary_secret = base64.b64decode(
+                get_secret_value_response["SecretBinary"]
+            )
+            secret = decoded_binary_secret
+        LOGGER.info("here")
+        return secret
+    # added as the validation exception was not being caught
+    except Exception as exception:
+        LOGGER.error("Exception: %s", exception)
+        raise

--- a/src/utils/environment_helpers.py
+++ b/src/utils/environment_helpers.py
@@ -25,11 +25,6 @@ def validate_env_variable(env_var_name):
 
 
 def get_database_password():
-    try:
-        password = validate_env_variable("DATABASE_PASSWORD")
-        return password
-    except Exception:
-        pass
     aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
     aws_region_name = validate_env_variable("REGION_NAME")
     return _get_aws_secret(aws_secret_name, aws_region_name)

--- a/src/utils/initialise_db.py
+++ b/src/utils/initialise_db.py
@@ -26,7 +26,7 @@ def init_db_engine() -> sqlalchemy.Engine:
     return sqlalchemy.create_engine(db_url, verbose=True)
 
 
-def init_db_connection() -> psycopg2.connection:
+def init_db_connection() -> psycopg2.extensions.connection:
     """
     Establish database connection
     """

--- a/src/utils/initialise_db.py
+++ b/src/utils/initialise_db.py
@@ -1,0 +1,39 @@
+"""
+This module contains functions to initialise db connections
+from environment variables
+"""
+
+import psycopg2
+import sqlalchemy
+
+from database.db_connection import create_connection
+from utils.environment_helpers import (
+    get_database_password,
+    validate_env_variable,
+)
+
+DATABASE_NAME = validate_env_variable("DATABASE_NAME")
+USERNAME = validate_env_variable("DATABASE_USERNAME")
+HOST = validate_env_variable("DATABASE_HOSTNAME")
+PORT = validate_env_variable("DATABASE_PORT")
+PASSWORD = get_database_password()
+
+
+def init_db_engine() -> sqlalchemy.Engine:
+    db_url = "postgresql://{0}:{1}@{2}:{3}/{4}".format(
+        USERNAME, PASSWORD, HOST, PORT, DATABASE_NAME
+    )
+    return sqlalchemy.create_engine(db_url, verbose=True)
+
+
+def init_db_connection() -> psycopg2.connection:
+    """
+    Establish database connection
+    """
+    return create_connection(
+        DATABASE_NAME,
+        USERNAME,
+        PASSWORD,
+        HOST,
+        PORT,
+    )

--- a/src/utils/initialise_db.py
+++ b/src/utils/initialise_db.py
@@ -7,10 +7,7 @@ import psycopg2
 import sqlalchemy
 
 from database.db_connection import create_connection
-from utils.environment_helpers import (
-    get_database_password,
-    validate_env_variable,
-)
+from utils.environment_helpers import get_aws_secret, validate_env_variable
 
 
 def init_db_engine() -> sqlalchemy.Engine:
@@ -21,7 +18,7 @@ def init_db_engine() -> sqlalchemy.Engine:
     username = validate_env_variable("DATABASE_USERNAME")
     host = validate_env_variable("DATABASE_HOSTNAME")
     port = validate_env_variable("DATABASE_PORT")
-    password = get_database_password()
+    password = _get_database_password()
 
     db_url = "postgresql://{0}:{1}@{2}:{3}/{4}".format(
         username, password, host, port, database_name
@@ -37,7 +34,7 @@ def init_db_connection() -> psycopg2.extensions.connection:
     username = validate_env_variable("DATABASE_USERNAME")
     host = validate_env_variable("DATABASE_HOSTNAME")
     port = validate_env_variable("DATABASE_PORT")
-    password = get_database_password()
+    password = _get_database_password()
 
     return create_connection(
         database_name,
@@ -46,3 +43,9 @@ def init_db_connection() -> psycopg2.extensions.connection:
         host,
         port,
     )
+
+
+def _get_database_password():
+    aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
+    aws_region_name = validate_env_variable("REGION_NAME")
+    return get_aws_secret(aws_secret_name, aws_region_name)

--- a/src/utils/initialise_db.py
+++ b/src/utils/initialise_db.py
@@ -12,28 +12,37 @@ from utils.environment_helpers import (
     validate_env_variable,
 )
 
-DATABASE_NAME = validate_env_variable("DATABASE_NAME")
-USERNAME = validate_env_variable("DATABASE_USERNAME")
-HOST = validate_env_variable("DATABASE_HOSTNAME")
-PORT = validate_env_variable("DATABASE_PORT")
-PASSWORD = get_database_password()
-
 
 def init_db_engine() -> sqlalchemy.Engine:
+    """
+    Initialise database engine from environment variables
+    """
+    database_name = validate_env_variable("DATABASE_NAME")
+    username = validate_env_variable("DATABASE_USERNAME")
+    host = validate_env_variable("DATABASE_HOSTNAME")
+    port = validate_env_variable("DATABASE_PORT")
+    password = get_database_password()
+
     db_url = "postgresql://{0}:{1}@{2}:{3}/{4}".format(
-        USERNAME, PASSWORD, HOST, PORT, DATABASE_NAME
+        username, password, host, port, database_name
     )
-    return sqlalchemy.create_engine(db_url, verbose=True)
+    return sqlalchemy.create_engine(db_url)
 
 
 def init_db_connection() -> psycopg2.extensions.connection:
     """
-    Establish database connection
+    Initialise database connection from environment variables
     """
+    database_name = validate_env_variable("DATABASE_NAME")
+    username = validate_env_variable("DATABASE_USERNAME")
+    host = validate_env_variable("DATABASE_HOSTNAME")
+    port = validate_env_variable("DATABASE_PORT")
+    password = get_database_password()
+
     return create_connection(
-        DATABASE_NAME,
-        USERNAME,
-        PASSWORD,
-        HOST,
-        PORT,
+        database_name,
+        username,
+        password,
+        host,
+        port,
     )

--- a/src/utils/tests/conftest.py
+++ b/src/utils/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Fixtures for utils tests"""
+import boto3
+import pytest
+from moto import mock_secretsmanager
+
+
+@pytest.fixture(scope="module")
+def moto_secrets_manager_with_password():
+    secret_value = {"SecretString": "mydatabasepassword"}
+    region_name = "us-east-1"
+    secret_name = "mysecret"
+    mock_secrets_manager = mock_secretsmanager()
+    mock_secrets_manager.start()
+    client = boto3.client("secretsmanager", region_name=region_name)
+    client.create_secret(Name=secret_name, SecretString=secret_value["SecretString"])
+    yield {
+        "secret_value": secret_value,
+        "region_name": region_name,
+        "secret_name": secret_name,
+    }

--- a/src/utils/tests/test_environment_helpers.py
+++ b/src/utils/tests/test_environment_helpers.py
@@ -1,0 +1,132 @@
+"""Unit tests for environment_helpers"""
+
+import boto3
+import pytest
+from moto import mock_secretsmanager
+
+from utils.environment_helpers import (
+    get_database_password,
+    validate_env_variable,
+)
+
+
+class TestValidateEnvVariable:
+    def test_validate_env_variable_success(self, monkeypatch):
+        """
+        Given an environment variable name
+        When the environment variable has a value
+        Then validate_env_variable should return the value of the environment variable
+        """
+        env_var_name = "DATABASE_PASSWORD"
+        monkeypatch.setenv(env_var_name, "my_password")
+        result = validate_env_variable(env_var_name)
+        assert result == "my_password"
+
+    def test_validate_env_variable_empty(self, monkeypatch):
+        """
+        Given an environment variable name
+        When the environment variable has an empty string as its value
+        Then validate_env_variable should raise an Exception
+        """
+        env_var_name = "EMPTY_VAR"
+        monkeypatch.setenv(env_var_name, "")
+        with pytest.raises(Exception):
+            validate_env_variable(env_var_name)
+
+    def test_validate_env_variable_failure(self):
+        """
+        Given an environment variable name
+        When the environment variable does not exist
+        Then validate_env_variable should raise an Exception
+        """
+        env_var_name = "NON_EXISTENT_VAR"
+        with pytest.raises(Exception):
+            validate_env_variable(env_var_name)
+
+
+class TestGetDatabasePassword:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_moto_secrets_manager(self):
+        secret_value = {"SecretString": "mydatabasepassword"}
+        region_name = "us-east-1"
+        secret_name = "mysecret"
+        mock_secrets_manager = mock_secretsmanager()
+        mock_secrets_manager.start()
+        client = boto3.client("secretsmanager", region_name=region_name)
+        client.create_secret(
+            Name=secret_name, SecretString=secret_value["SecretString"]
+        )
+        yield {
+            "secret_value": secret_value,
+            "region_name": region_name,
+            "secret_name": secret_name,
+        }
+
+    def test_get_database_password_with_database_password(self, monkeypatch):
+        """
+        Given the DATABASE_PASSWORD environment variable is set
+        When get_database_password is called
+        Then get_database_password should return the value of the DATABASE_PASSWORD environment variable
+        """
+        monkeypatch.setenv("DATABASE_PASSWORD", "my_database_password")
+        monkeypatch.setenv("SECRET_PASSWORD_LOOKUP", "my_secret_name")
+        monkeypatch.setenv("REGION_NAME", "us-west-2")
+
+        assert get_database_password() == "my_database_password"
+
+    def test_get_database_password_with_valid_aws_secret(
+        self, monkeypatch, setup_moto_secrets_manager
+    ):
+        """
+        Given a valid AWS secret containing the database password
+        When I call get_database_password
+        Then I should get the correct database password
+        """
+        monkeypatch.setenv(
+            "SECRET_PASSWORD_LOOKUP", setup_moto_secrets_manager["secret_name"]
+        )
+        monkeypatch.setenv("REGION_NAME", setup_moto_secrets_manager["region_name"])
+
+        password = get_database_password()
+
+        assert password == setup_moto_secrets_manager["secret_value"]["SecretString"]
+
+    def test_get_database_password_with_no_env_variables(self):
+        """
+        Given no DATABASE_PASSWORD, SECRET_PASSWORD_LOOKUP or REGION_NAME
+        environment variables are set
+        When get_database_password is called
+        Then get_database_password should raise an Exception
+        """
+        with pytest.raises(Exception):
+            get_database_password()
+
+    def test_get_database_password_with_invalid_aws_secret_password_lookup(
+        self, monkeypatch, setup_moto_secrets_manager
+    ):
+        """
+        Given an invalid AWS secret name
+        When I call get_database_password
+        Then I should get an exception
+        """
+        monkeypatch.setenv("SECRET_PASSWORD_LOOKUP", "wrong_password")
+        monkeypatch.setenv("REGION_NAME", setup_moto_secrets_manager["region_name"])
+
+        with pytest.raises(Exception):
+            get_database_password()
+
+    def test_get_database_password_with_invalid_aws_region(
+        self, monkeypatch, setup_moto_secrets_manager
+    ):
+        """
+        Given an invalid AWS region
+        When I call get_database_password
+        Then I should get an exception
+        """
+        monkeypatch.setenv(
+            "SECRET_PASSWORD_LOOKUP", setup_moto_secrets_manager["secret_name"]
+        )
+        monkeypatch.setenv("REGION_NAME", "wrong-region")
+
+        with pytest.raises(Exception):
+            get_database_password()

--- a/src/utils/tests/test_initialise_db.py
+++ b/src/utils/tests/test_initialise_db.py
@@ -7,7 +7,9 @@ from utils.initialise_db import init_db_connection, init_db_engine
 
 
 @mock.patch("sqlalchemy.create_engine")
-def test_init_db_engine(mock_create_engine, monkeypatch):
+def test_init_db_engine(
+    mock_create_engine, monkeypatch, moto_secrets_manager_with_password
+):
     """
     Given: The environment variables for the database are set
     When: The `init_db_engine` function is called
@@ -17,19 +19,24 @@ def test_init_db_engine(mock_create_engine, monkeypatch):
     monkeypatch.setenv("DATABASE_USERNAME", "myuser")
     monkeypatch.setenv("DATABASE_HOSTNAME", "localhost")
     monkeypatch.setenv("DATABASE_PORT", "5432")
-    monkeypatch.setenv("DATABASE_PASSWORD", "mypass")
+    monkeypatch.setenv(
+        "SECRET_PASSWORD_LOOKUP", moto_secrets_manager_with_password["secret_name"]
+    )
+    monkeypatch.setenv("REGION_NAME", moto_secrets_manager_with_password["region_name"])
 
     mock_create_engine.return_value = MagicMock()
 
     engine = init_db_engine()
 
-    expected_db_url = "postgresql://myuser:mypass@localhost:5432/mydb"
-    mock_create_engine.assert_called_once_with(expected_db_url, verbose=True)
+    expected_db_url = "postgresql://myuser:mydatabasepassword@localhost:5432/mydb"
+    mock_create_engine.assert_called_once_with(expected_db_url)
     assert engine == mock_create_engine.return_value
 
 
 @mock.patch("utils.initialise_db.create_connection")
-def test_init_db_connection(mock_create_engine, monkeypatch):
+def test_init_db_connection(
+    mock_create_engine, monkeypatch, moto_secrets_manager_with_password
+):
     """
     Given: The environment variables for the database are set
     When: The `init_db_connection` function is called
@@ -39,13 +46,16 @@ def test_init_db_connection(mock_create_engine, monkeypatch):
     monkeypatch.setenv("DATABASE_USERNAME", "myuser")
     monkeypatch.setenv("DATABASE_HOSTNAME", "localhost")
     monkeypatch.setenv("DATABASE_PORT", "5432")
-    monkeypatch.setenv("DATABASE_PASSWORD", "mypass")
+    monkeypatch.setenv(
+        "SECRET_PASSWORD_LOOKUP", moto_secrets_manager_with_password["secret_name"]
+    )
+    monkeypatch.setenv("REGION_NAME", moto_secrets_manager_with_password["region_name"])
 
     mock_create_engine.return_value = MagicMock()
 
     engine = init_db_connection()
 
     mock_create_engine.assert_called_once_with(
-        "mydb", "myuser", "mypass", "localhost", "5432"
+        "mydb", "myuser", "mydatabasepassword", "localhost", "5432"
     )
     assert engine == mock_create_engine.return_value

--- a/src/utils/tests/test_initialise_db.py
+++ b/src/utils/tests/test_initialise_db.py
@@ -1,0 +1,54 @@
+"""Unit tests for the initialise_db module"""
+
+from unittest import mock
+
+from mock import MagicMock
+
+
+@mock.patch("sqlalchemy.create_engine")
+def test_init_db_engine(mock_create_engine, monkeypatch):
+    """
+    Given: The environment variables for the database are set
+    When: The `init_db_engine` function is called
+    Then create_engine was called with the correct arguments
+    """
+    monkeypatch.setenv("DATABASE_NAME", "mydb")
+    monkeypatch.setenv("DATABASE_USERNAME", "myuser")
+    monkeypatch.setenv("DATABASE_HOSTNAME", "localhost")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_PASSWORD", "mypass")
+
+    mock_create_engine.return_value = MagicMock()
+
+    from utils.initialise_db import init_db_engine
+
+    engine = init_db_engine()
+
+    expected_db_url = "postgresql://myuser:mypass@localhost:5432/mydb"
+    mock_create_engine.assert_called_once_with(expected_db_url, verbose=True)
+    assert engine == mock_create_engine.return_value
+
+
+@mock.patch("utils.initialise_db.create_connection")
+def test_init_db_connection(mock_create_engine, monkeypatch):
+    """
+    Given: The environment variables for the database are set
+    When: The `init_db_connection` function is called
+    Then create_connection was called with the correct arguments
+    """
+    monkeypatch.setenv("DATABASE_NAME", "mydb")
+    monkeypatch.setenv("DATABASE_USERNAME", "myuser")
+    monkeypatch.setenv("DATABASE_HOSTNAME", "localhost")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_PASSWORD", "mypass")
+
+    mock_create_engine.return_value = MagicMock()
+
+    from utils.initialise_db import init_db_connection
+
+    engine = init_db_connection()
+
+    mock_create_engine.assert_called_once_with(
+        "mydb", "myuser", "mypass", "localhost", "5432"
+    )
+    assert engine == mock_create_engine.return_value

--- a/src/utils/tests/test_initialise_db.py
+++ b/src/utils/tests/test_initialise_db.py
@@ -1,8 +1,9 @@
 """Unit tests for the initialise_db module"""
-
 from unittest import mock
 
 from mock import MagicMock
+
+from utils.initialise_db import init_db_connection, init_db_engine
 
 
 @mock.patch("sqlalchemy.create_engine")
@@ -19,8 +20,6 @@ def test_init_db_engine(mock_create_engine, monkeypatch):
     monkeypatch.setenv("DATABASE_PASSWORD", "mypass")
 
     mock_create_engine.return_value = MagicMock()
-
-    from utils.initialise_db import init_db_engine
 
     engine = init_db_engine()
 
@@ -43,8 +42,6 @@ def test_init_db_connection(mock_create_engine, monkeypatch):
     monkeypatch.setenv("DATABASE_PASSWORD", "mypass")
 
     mock_create_engine.return_value = MagicMock()
-
-    from utils.initialise_db import init_db_connection
 
     engine = init_db_connection()
 

--- a/terraform/modules/lambda_s3/lambda.tf
+++ b/terraform/modules/lambda_s3/lambda.tf
@@ -300,12 +300,11 @@ module "lambda-determine-replacements-caselaw" {
 
   environment_variables = {
     DATABASE_NAME          = "rules"
-    TABLE_NAME             = "rules"
-    USERNAME               = "root"
-    PORT                   = "5432"
+    DATABASE_USERNAME      = "root"
+    DATABASE_PORT          = "5432"
     SECRET_PASSWORD_LOOKUP = "${var.postgress_master_password_secret_id}"
     REGION_NAME            = "${local.region}"
-    HOSTNAME               = "${var.postgress_hostname}"
+    DATABASE_HOSTNAME      = "${var.postgress_hostname}"
 
     DEST_QUEUE_NAME     = aws_sqs_queue.replacement-caselaw-queue.url
     RULES_FILE_BUCKET   = "${module.rules_bucket.s3_bucket_id}"
@@ -429,12 +428,11 @@ module "lambda-determine-replacements-legislation" {
 
   environment_variables = {
     DATABASE_NAME          = "rules"
-    TABLE_NAME             = "rules"
-    USERNAME               = "root"
-    PORT                   = "5432"
+    DATABASE_USERNAME      = "root"
+    DATABASE_PORT          = "5432"
+    DATABASE_HOSTNAME      = "${var.postgress_hostname}"
     SECRET_PASSWORD_LOOKUP = "${var.postgress_master_password_secret_id}"
     REGION_NAME            = "${local.region}"
-    HOSTNAME               = "${var.postgress_hostname}"
 
     DEST_QUEUE_NAME = aws_sqs_queue.replacement-legislation-queue.url
 
@@ -986,12 +984,11 @@ module "lambda-update-legislation-table" {
 
   environment_variables = {
     DATABASE_NAME          = "rules"
-    TABLE_NAME             = "rules"
-    USERNAME               = "root"
-    PORT                   = "5432"
+    DATABASE_USERNAME      = "root"
+    DATABASE_HOSTNAME      = var.postgress_hostname
+    DATABASE_PORT          = "5432"
     SECRET_PASSWORD_LOOKUP = "${var.postgress_master_password_secret_id}"
     REGION_NAME            = local.region
-    HOSTNAME               = var.postgress_hostname
     SPARQL_USERNAME        = data.aws_secretsmanager_secret_version.sparql_username_credentials.secret_string
     SPARQL_PASSWORD        = data.aws_secretsmanager_secret_version.sparql_password_credentials.secret_string
   }
@@ -1108,16 +1105,11 @@ module "lambda-update-rules-processor" {
 
   environment_variables = {
     DATABASE_NAME          = "rules"
-    TABLE_NAME             = "rules"
-    USERNAME               = "root"
-    PORT                   = "5432"
+    DATABASE_USERNAME      = "root"
+    DATABASE_HOSTNAME      = "${var.postgress_hostname}"
+    DATABASE_PORT          = "5432"
     SECRET_PASSWORD_LOOKUP = "${var.postgress_master_password_secret_id}"
     REGION_NAME            = "${local.region}"
-    HOSTNAME               = "${var.postgress_hostname}"
-    # SPARQL_USERNAME = "${var.sparql_username}"
-    # SPARQL_PASSWORD = "${var.sparql_password}"
-    SPARQL_USERNAME = ""
-    SPARQL_PASSWORD = ""
   }
 
   cloudwatch_logs_retention_in_days = 365


### PR DESCRIPTION
This PR:

- Reduces database env var reading boiler plate
- make database env var names more explicit (without prefixing DATABASE_ to PASSWORD to make DATABASE_PASSWORD, sourcing a .env locally would mess up the shell so this was necessary as I added that new env as discussed in comments)
- and remove unused TABLE_NAME env var (discussed in comments)