### PR TITLE
remove_duplicates as part of update_legislation_table lambda

### DIFF
--- a/src/lambdas/update_legislation_table/index.py
+++ b/src/lambdas/update_legislation_table/index.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Optional
 
+from update_legislation_table.database import remove_duplicates
 from update_legislation_table.fetch_legislation import fetch_legislation
 
 from utils.environment_helpers import validate_env_variable
@@ -50,6 +51,8 @@ def update_legislation_table(trigger_date: Optional[int]):
     legislation_data_frame.to_sql(
         LEGISLATION_TABLE_NAME, engine, if_exists="append", index=False
     )
+    with engine.connect() as db_conn:
+        remove_duplicates(db_conn, LEGISLATION_TABLE_NAME)
     engine.dispose()
 
     LOGGER.info("Legislation updated")

--- a/src/lambdas/update_legislation_table/test_update_legislation.py
+++ b/src/lambdas/update_legislation_table/test_update_legislation.py
@@ -21,9 +21,26 @@ postgresql_my = factories.postgresql("postgresql_my_proc")
 def test_db_connection(postgresql_my):
     conn = postgresql_my
     conn.autocommit = True
-    conn.cursor().execute("CREATE DATABASE ukpga_lookup")
+    sql_query = """
+    CREATE TABLE ukpga_lookup (
+        ref VARCHAR(100) NOT NULL,
+        title VARCHAR(100) NOT NULL,
+        ref_version VARCHAR(100) NOT NULL,
+        shorttitle VARCHAR(100) NOT NULL,
+        citation VARCHAR(100) NOT NULL,
+        acronymcitation VARCHAR(100) NOT NULL,
+        year BIGINT NOT NULL,
+        candidate_titles VARCHAR(100) NOT NULL,
+        for_fuzzy BOOLEAN NOT NULL
+    );
+    INSERT INTO ukpga_lookup (ref, title, ref_version, shorttitle, citation, acronymcitation, year, candidate_titles, for_fuzzy)
+    VALUES
+        ('a', 'a_title', 'a_ref_version', 'a_shorttitle', 'a_citation', 'a_acronymcitation', 2001, 'a_candidate_titles', true),
+        ('b', 'b_title', 'b_ref_version', 'b_shorttitle', 'b_citation', 'b_acronymcitation', 2001, 'b_candidate_titles', true)
+    """
+    conn.cursor().execute(sql_query)
     yield conn
-    conn.cursor().execute("DROP DATABASE ukpga_lookup")
+    conn.cursor().execute("DROP TABLE ukpga_lookup")
 
 
 @pytest.fixture(scope="function")
@@ -55,7 +72,20 @@ def test_update_legislation_table(
     Then the ukpga_lookup table in the database is appended to with the legislation
         entries from fetch_legislation
     """
-    mock_fetch_legislation.return_value = pd.DataFrame({"col1": [1, 3], "col2": [2, 4]})
+
+    mock_fetch_legislation.return_value = pd.DataFrame(
+        {
+            "ref": ["b", "c"],
+            "title": ["b_title", "c_title"],
+            "ref_version": ["b_ref_version", "c_ref_version"],
+            "shorttitle": ["b_shorttitle", "c_shorttitle"],
+            "citation": ["b_citation", "c_citation"],
+            "acronymcitation": ["b_acronymcitation", "c_acronymcitation"],
+            "year": [2001, 2001],
+            "candidate_titles": ["b_candidate_titles", "c_candidate_titles"],
+            "for_fuzzy": [True, True],
+        }
+    )
 
     monkeypatch.setenv("SPARQL_USERNAME", "test_user")
     monkeypatch.setenv("SPARQL_PASSWORD", "test_password")
@@ -72,5 +102,38 @@ def test_update_legislation_table(
     update_legislation_table(trigger_date)
     mock_fetch_legislation.assert_called_with("test_user", "test_password", 7)
     rows = test_db_connection.cursor().execute("SELECT * FROM ukpga_lookup").fetchall()
-    assert len(rows) == 2
-    assert rows == [(1, 2), (3, 4)]
+    assert rows == [
+        (
+            "a",
+            "a_title",
+            "a_ref_version",
+            "a_shorttitle",
+            "a_citation",
+            "a_acronymcitation",
+            2001,
+            "a_candidate_titles",
+            True,
+        ),
+        (
+            "b",
+            "b_title",
+            "b_ref_version",
+            "b_shorttitle",
+            "b_citation",
+            "b_acronymcitation",
+            2001,
+            "b_candidate_titles",
+            True,
+        ),
+        (
+            "c",
+            "c_title",
+            "c_ref_version",
+            "c_shorttitle",
+            "c_citation",
+            "c_acronymcitation",
+            2001,
+            "c_candidate_titles",
+            True,
+        ),
+    ]

--- a/src/lambdas/update_legislation_table/update_legislation_table/database.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/database.py
@@ -1,0 +1,35 @@
+"""
+This module contains utility functions for working with databases using SQLAlchemy.
+"""
+
+from sqlalchemy import Connection, text
+
+
+def remove_duplicates(db_conn: Connection, table_name: str):
+    """
+    Removes duplicate rows from the specified table in the database.
+    Uses a SQL query to identify duplicate rows based on all columns, except for the
+    unique row identifier, and deletes all but one of the duplicate rows.
+    Parameters
+    ----------
+    db_conn: sqlalchemy.engine.Connection, required.
+        The SQLAlchemy database connection object.
+    table_name: str, required.
+        The name of the table to remove duplicates from.
+    Returns
+    -------
+    None
+    """
+    sql_string = f"""
+        DELETE FROM {table_name}
+        WHERE ctid IN (
+        SELECT ctid
+        FROM (
+            SELECT ctid, ROW_NUMBER() OVER(PARTITION BY {table_name}.*) AS rnum
+            FROM {table_name}
+        ) t
+        WHERE t.rnum > 1
+        );
+    """
+    db_conn.execute(text(sql_string))
+    db_conn.commit()

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_remove_duplicates.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_remove_duplicates.py
@@ -1,0 +1,29 @@
+from sqlalchemy import create_engine, text
+from testing.postgresql import Postgresql
+from update_legislation_table.database import remove_duplicates
+
+
+def test_remove_duplicates():
+    """
+    Given the test table has duplicate rows
+    When the function to remove_duplicates is called
+    Then the number of rows in the table should be reduced
+        due to the removed duplicates
+    """
+    with Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        with engine.connect() as conn:
+            conn.execute(
+                text("CREATE TABLE test_table (name VARCHAR(255), age INTEGER)")
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO test_table (name, age) VALUES ('John', 30), ('John', 30), ('Sarah', 25)"
+                )
+            )
+            conn.commit()
+
+            remove_duplicates(conn, "test_table")
+
+            result = conn.execute(text("SELECT COUNT(*) FROM test_table")).scalar()
+            assert result == 2


### PR DESCRIPTION
https://trello.com/c/RTIrUXGl/640-enrichment-legislation-table-not-been-updated-in-ages

The enrichment service has a db which just mirrors the legislation api's db (for efficiency reasons.

Without this PR, the lambda used to keep it up to date `update_legislation_table` _could_ add duplicate entries to the db if the trigger_date went back to a date already covered by the db.

This PR addresses that and removes any duplicate entries at the end of the `update_legislation_table` lambda.