### PR TITLE
Include database shared folder in update-legislation-table lambda doc…

### DIFF
--- a/src/lambdas/update_legislation_table/Dockerfile
+++ b/src/lambdas/update_legislation_table/Dockerfile
@@ -13,5 +13,6 @@ RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 # Copy the rest of the code
 COPY . ${LAMBDA_TASK_ROOT}
 COPY utils/ ${LAMBDA_TASK_ROOT}/utils/
+COPY database/ ${LAMBDA_TASK_ROOT}/database/
 
 CMD [ "index.lambda_handler" ]


### PR DESCRIPTION
…kerfile

Always something else - I hadnt run the full lambda in the dockerfile last time - one of the imported modules in the lambda file depends on the shared database folder so also had to include that. Have tested and now get passed the import of the folder.