### PR TITLE
Fix update_legislation_table and update_rules_processor FINALLY

### DIFF
--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -61,6 +61,8 @@ jobs:
           cp -r utils/*.py lambdas/determine_replacements_caselaw/utils/
           mkdir lambdas/update_legislation_table/utils
           cp -r utils/*.py lambdas/update_legislation_table/utils/
+          mkdir lambdas/update_legislation_table/database
+          cp -r database/*.py lambdas/update_legislation_table/database/
           mkdir lambdas/determine_replacements_legislation/legislation_extraction
           cp -r legislation_extraction/*.* lambdas/determine_replacements_legislation/legislation_extraction/
           cp legislation_extraction/requirements.txt lambdas/determine_replacements_legislation/
@@ -93,6 +95,8 @@ jobs:
           cp -r utils/*.py lambdas/fetch_xml/utils/
           mkdir lambdas/update_rules_processor/utils
           cp -r utils/*.py lambdas/update_rules_processor/utils/
+          mkdir lambdas/update_rules_processor/database
+          cp -r database/*.py lambdas/update_rules_processor/database/
           mkdir -p lambdas/make_replacements/replacer
           cp -r replacer/*.py lambdas/make_replacements/replacer/
 

--- a/src/lambdas/update_legislation_table/Dockerfile
+++ b/src/lambdas/update_legislation_table/Dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     rm -Rf /var/cache/yum
 
 # Copy only the requirements file first and install dependencies
-COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+COPY requirements.txt ${LAMBDA_TASK_ROOT}
 RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Copy the rest of the code

--- a/src/lambdas/update_rules_processor/Dockerfile
+++ b/src/lambdas/update_rules_processor/Dockerfile
@@ -1,31 +1,18 @@
-# FROM public.ecr.aws/lambda/python:3.9
 FROM public.ecr.aws/lambda/python:3.8
-# Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
-# FROM lambci/lambda:build-python3.6
 
-
-# Set the timezone
-# ENV TZ=Europe/London
-# RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-# Set some environment variables. PYTHONUNBUFFERED keeps Python from buffering out standard
-# output stream, which means that logs can be delivered to the user quickly.
-# PYTHONDONTWRITEBYTECODE keeps Python from writing the .pyc files, which are unnecessary in this case
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
 
-
+# Install system dependencies
 RUN yum update -y && \
     rm -Rf /var/cache/yum
 
+# Copy only the requirements file first and install dependencies
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
-COPY utils/ ${LAMBDA_TASK_ROOT}/utils/
-
 RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
-# RUN pip install psycopg2-binary==2.9.2 --target "${LAMBDA_TASK_ROOT}"
-# RUN wget https://github.com/jkehler/awslambda-psycopg2/archive/refs/heads/master.zip
 
-# RUN pip install aws-psycopg2 --target "${LAMBDA_TASK_ROOT}"
-
-COPY index.py ${LAMBDA_TASK_ROOT}
+# Copy the rest of the code
+COPY . ${LAMBDA_TASK_ROOT}
+COPY utils/ ${LAMBDA_TASK_ROOT}/utils/
+COPY database/ ${LAMBDA_TASK_ROOT}/database/
 
 CMD [ "index.lambda_handler" ]


### PR DESCRIPTION
Let's hope this fixes update_legislation_table once and for all. locally I had copied the database folder into the update_leg folder so building the image worked.

Also double checked what other lambdas used the init_db functions added recently to the database shared folder and noticed we needed to fix `update_rules_processor` also.


We need to sort out the whole copying of shared folders - which we have a ticket for.

Also need to start running the unit tests in the same env that the lambdas run in so we dont have these issues once we merged in to main. But that will be a separate ticket. Probably a followup to the ticket on shared folders.