### PR TITLE
Upgrade pandas to 1.5.3

### DIFF
--- a/src/lambdas/update_legislation_table/requirements.txt
+++ b/src/lambdas/update_legislation_table/requirements.txt
@@ -1,4 +1,4 @@
 psycopg2-binary==2.9.1
-pandas==1.1.5
+pandas==1.5.3
 sqlalchemy==2.0.4
 SPARQLWrapper==2.0.0


### PR DESCRIPTION
We had updated sqlalchemy to 2.0.0 but only newer versions of pandas df.to_sql is compatible with it, so upgrading pandas  to 1.5.3.
- again not caught by unit tests in ci due to how we have the test env/lambda env set up - ticket to address this exists.

more info on this here: https://stackoverflow.com/questions/75273632/got-multiple-values-for-argument-schema