### PR TITLE
Include utils shared folder in determine_oblique_references lambda do…

### DIFF
--- a/src/lambdas/determine_oblique_references/Dockerfile
+++ b/src/lambdas/determine_oblique_references/Dockerfile
@@ -1,35 +1,13 @@
-
 FROM public.ecr.aws/lambda/python:3.9
-# FROM public.ecr.aws/lambda/python:3.8
-# Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
-# FROM lambci/lambda:build-python3.6
-# FROM public.ecr.aws/lambda/python:3.6
 
-COPY index.py ${LAMBDA_TASK_ROOT}
-# Set the timezone
-# ENV TZ=Europe/London
-# RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-# Set some environment variables. PYTHONUNBUFFERED keeps Python from buffering out standard
-# output stream, which means that logs can be delivered to the user quickly.
-# PYTHONDONTWRITEBYTECODE keeps Python from writing the .pyc files, which are unnecessary in this case
-# ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
-
-
-# RUN yum update -y && \
-#     rm -Rf /var/cache/yum
-
+# Copy only the requirements file first and install dependencies
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
+RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Copy the rest of the code
+COPY . ${LAMBDA_TASK_ROOT}
+COPY utils/ ${LAMBDA_TASK_ROOT}/utils/
 COPY replacer/ ${LAMBDA_TASK_ROOT}/replacer/
 COPY oblique_references/ ${LAMBDA_TASK_ROOT}/oblique_references/
 
-RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
-# RUN pip install psycopg2-binary==2.9.2 --target "${LAMBDA_TASK_ROOT}"
-# RUN wget https://github.com/jkehler/awslambda-psycopg2/archive/refs/heads/master.zip
-
-# RUN pip install aws-psycopg2 --target "${LAMBDA_TASK_ROOT}"
-
-# RUN ls -la ${LAMBDA_TASK_ROOT}/*
-
 CMD [ "index.handler" ]
-# CMD [ "index.lambda_handler" ]


### PR DESCRIPTION
…ckerfile

Got an error on staging for this last night: https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Ftna-s3-tna-staging-determine-oblique-references/log-events/2023$252F05$252F04$252F$255B$2524LATEST$255D2b7f746648a24eba86258c256bc04bf9

This one fell through the cracks from when I refactored the env variable logic into a function in the utils folder.