### PR TITLE
Reduce duplication in queue tf file

### DIFF
--- a/terraform/modules/lambda_s3/variables.tf
+++ b/terraform/modules/lambda_s3/variables.tf
@@ -1,3 +1,9 @@
+# Create SNS topic subscription for each developer
+variable "developer_emails" {
+  type    = list(string)
+  default = ["anthony.hashemi@nationalarchives.gov.uk", "david.mckee@dxw.com"]
+}
+
 variable "aws_profile" {
   type    = string
   default = "default"


### PR DESCRIPTION
https://trello.com/c/NrZGHaJg/997-some-enrichment-lambda-functions-arent-alerting-us-of-errors

Breaking Changes:

- all the topics into one new topic called `Enrichment Error` as opposed to specific ones like `Fetch XML Error`, but the underlying errors alerts for each lambda function will still exist and are distinguishable within each topic.

Refactor-Only Changes:

- All lambda functions now have their corresponding error `aws_cloudwatch_metric_alarm` created  dynamically rather than lots of duplicated boilerplate - utilising the `count` meta-argument https://developer.hashicorp.com/terraform/language/meta-arguments/count
- Subscriptions to the new topic has less boilerplate by using a email list variable.