### PR TITLE
Double determine-replacements-caselaw ram

### DIFF
--- a/terraform/modules/lambda_s3/lambda.tf
+++ b/terraform/modules/lambda_s3/lambda.tf
@@ -208,7 +208,7 @@ module "lambda-determine-replacements-caselaw" {
   create_current_version_allowed_triggers = false # !var.use_container_image
 
   timeout     = 900
-  memory_size = 5120
+  memory_size = 10240
 
   attach_policy_statements = true
   policy_statements = {


### PR DESCRIPTION
There were OOM issues with the megajudgment.

https://trello.com/c/TDttis5D/1180-megajudgment-enrichment-determine-replacements-caselaw-oom-error