### PR TITLE
Fcl 151 enrichment broken for documents without header tags

### DIFF
--- a/src/lambdas/make_replacements/index.py
+++ b/src/lambdas/make_replacements/index.py
@@ -3,12 +3,10 @@
 import json
 import logging
 import os
-import re
 
 import boto3
-from bs4 import BeautifulSoup
 
-from replacer.make_replacments import split_text_by_closing_header_tag
+from replacer.make_replacments import make_post_header_replacements
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
@@ -38,47 +36,6 @@ def upload_contents(source_key, text_content):
     s3 = boto3.resource("s3")
     object = s3.Object(DEST_BUCKET, filename)
     object.put(Body=text_content)
-
-
-def detect_reference(text, etype):
-    """
-    Detect citation references.
-    :param text: text to be searched for references
-    :param etype: type of reference to be detected
-    :returns references: List(Tuple[((start, end), detected_ref)]), of detected legislation
-    """
-    patterns = {
-        "legislation": r"<ref(((?!ref>).)*)(.*?)ref>",
-    }
-
-    references = [(m.span(), m.group()) for m in re.finditer(patterns[etype], text)]
-    return references
-
-
-def sanitize_judgment(file_content):
-    remove_from_judgment = []
-    list_of_references = detect_reference(file_content, "legislation")
-    for i in list_of_references:
-        opening = i[1].split(">")[0] + ">"
-        remove_from_judgment.append((opening, ""))
-        remove_from_judgment.append(("</ref>", ""))
-
-    for k, v in remove_from_judgment:
-        file_content = file_content.replace(k, v)
-
-    soup = BeautifulSoup(file_content, "xml")
-    enriched_date = soup.find_all("FRBRdate", {"name": "tna-enriched"})
-    if enriched_date:
-        for i in enriched_date:
-            i.decompose()
-    engine_version = soup.find_all("uk:tna-enrichment-engine")
-    if engine_version:
-        for i in engine_version:
-            i.decompose()
-
-    soup_string = str(soup)
-
-    return soup_string
 
 
 def process_event(sqs_rec):
@@ -126,91 +83,6 @@ def process_event(sqs_rec):
         file_content, replacement_file_content
     )
     upload_contents(filename, full_replaced_text_content)
-
-
-def make_post_header_replacements(
-    original_content: str, post_header_replacement_content: str
-) -> str:
-    """
-    Replaces the content following a closing header tag in a legal document with new content.
-    If there is no closing header tag, then we replace the full content.
-
-    Note:
-    - This function assumes a specific structure of the legal document with closing header tags.
-
-    Args:
-        original_content (str): The original content of the legal document.
-        post_header_replacement_content (str): The replacement content to insert after the header.
-
-    Returns:
-        str: The modified legal document content with the replacement applied.
-    """
-    cleaned_file_content = sanitize_judgment(original_content)
-    document_split_by_header = split_text_by_closing_header_tag(cleaned_file_content)
-
-    post_header_content = document_split_by_header[2]
-
-    replaced_post_header_content = replace_text_content(
-        post_header_content, post_header_replacement_content
-    )
-    LOGGER.info("Got post-header replacement text content")
-    print(replaced_post_header_content)
-
-    document_split_by_header[2] = replaced_post_header_content
-    full_replaced_text_content = "".join(document_split_by_header)
-
-    return full_replaced_text_content
-
-
-def replace_text_content(file_content, replacements_content):
-    """
-    Run the replacer pipeline to make replacements on caselaw, legislation and abbreviations
-    """
-    replacements = []
-
-    replacement_tuples_case = []
-    replacement_tuples_leg = []
-    replacement_tuples_abb = []
-
-    tuple_file = replacements_content
-    LOGGER.info("tuple_file")
-    print(tuple_file)
-    LOGGER.info("---lines--")
-
-    for line in tuple_file.splitlines():
-        LOGGER.debug(line)
-        replacements.append(json.loads(line))
-
-    for i in replacements:
-        key, value = list(i.items())[0]
-
-        LOGGER.info("replacements")
-        if key == "case":
-            case_law_tuple = tuple(i["case"])
-            replacement_tuples_case.append(case_law_tuple)
-
-        elif key == "leg":
-            leg_tuple = tuple(i["leg"])
-            replacement_tuples_leg.append(leg_tuple)
-
-        else:
-            abb_tuple = tuple(i["abb"])
-            replacement_tuples_abb.append(abb_tuple)
-
-    LOGGER.info("Replacement caselaw")
-    print(replacement_tuples_case)
-
-    from replacer.replacer_pipeline import replacer_pipeline
-
-    file_data_enriched = replacer_pipeline(
-        file_content,
-        replacement_tuples_case,
-        replacement_tuples_leg,
-        replacement_tuples_abb,
-    )
-    LOGGER.info("Judgment enriched")
-
-    return file_data_enriched
 
 
 DEST_BUCKET = validate_env_variable("DEST_BUCKET_NAME")

--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -1,5 +1,138 @@
+import json
+import logging
 import re
 from typing import List
+
+from bs4 import BeautifulSoup
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.DEBUG)
+
+
+def make_post_header_replacements(
+    original_content: str, post_header_replacement_content: str
+) -> str:
+    """
+    Replaces the content following a closing header tag in a legal document with new content.
+    If there is no closing header tag, then we replace the full content.
+
+    Note:
+    - This function assumes a specific structure of the legal document with closing header tags.
+
+    Args:
+        original_content (str): The original content of the legal document.
+        post_header_replacement_content (str): The replacement content to insert after the header.
+
+    Returns:
+        str: The modified legal document content with the replacement applied.
+    """
+    cleaned_file_content = sanitize_judgment(original_content)
+    document_split_by_header = split_text_by_closing_header_tag(cleaned_file_content)
+
+    post_header_content = document_split_by_header[2]
+
+    replaced_post_header_content = replace_text_content(
+        post_header_content, post_header_replacement_content
+    )
+    LOGGER.info("Got post-header replacement text content")
+    print(replaced_post_header_content)
+
+    document_split_by_header[2] = replaced_post_header_content
+    full_replaced_text_content = "".join(document_split_by_header)
+
+    return full_replaced_text_content
+
+
+def replace_text_content(file_content, replacements_content):
+    """
+    Run the replacer pipeline to make replacements on caselaw, legislation and abbreviations
+    """
+    replacements = []
+
+    replacement_tuples_case = []
+    replacement_tuples_leg = []
+    replacement_tuples_abb = []
+
+    tuple_file = replacements_content
+    LOGGER.info("tuple_file")
+    print(tuple_file)
+    LOGGER.info("---lines--")
+
+    for line in tuple_file.splitlines():
+        LOGGER.debug(line)
+        replacements.append(json.loads(line))
+
+    for i in replacements:
+        key, value = list(i.items())[0]
+
+        LOGGER.info("replacements")
+        if key == "case":
+            case_law_tuple = tuple(i["case"])
+            replacement_tuples_case.append(case_law_tuple)
+
+        elif key == "leg":
+            leg_tuple = tuple(i["leg"])
+            replacement_tuples_leg.append(leg_tuple)
+
+        else:
+            abb_tuple = tuple(i["abb"])
+            replacement_tuples_abb.append(abb_tuple)
+
+    LOGGER.info("Replacement caselaw")
+    print(replacement_tuples_case)
+
+    from replacer.replacer_pipeline import replacer_pipeline
+
+    file_data_enriched = replacer_pipeline(
+        file_content,
+        replacement_tuples_case,
+        replacement_tuples_leg,
+        replacement_tuples_abb,
+    )
+    LOGGER.info("Judgment enriched")
+
+    return file_data_enriched
+
+
+def detect_reference(text, etype):
+    """
+    Detect citation references.
+    :param text: text to be searched for references
+    :param etype: type of reference to be detected
+    :returns references: List(Tuple[((start, end), detected_ref)]), of detected legislation
+    """
+    patterns = {
+        "legislation": r"<ref(((?!ref>).)*)(.*?)ref>",
+    }
+
+    references = [(m.span(), m.group()) for m in re.finditer(patterns[etype], text)]
+    return references
+
+
+def sanitize_judgment(file_content):
+    remove_from_judgment = []
+    list_of_references = detect_reference(file_content, "legislation")
+    for i in list_of_references:
+        opening = i[1].split(">")[0] + ">"
+        remove_from_judgment.append((opening, ""))
+        remove_from_judgment.append(("</ref>", ""))
+
+    for k, v in remove_from_judgment:
+        file_content = file_content.replace(k, v)
+
+    soup = BeautifulSoup(file_content, "xml")
+    enriched_date = soup.find_all("FRBRdate", {"name": "tna-enriched"})
+    if enriched_date:
+        for i in enriched_date:
+            i.decompose()
+    engine_version = soup.find_all("uk:tna-enrichment-engine")
+    if engine_version:
+        for i in engine_version:
+            i.decompose()
+
+    soup_string = str(soup)
+
+    return soup_string
 
 
 def split_text_by_closing_header_tag(file_content: str) -> List[str]:

--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -117,14 +117,10 @@ def sanitize_judgment(file_content):
     return soup_string
 
 
-def _decompose_elements(soup, name, filter=None):
-    if filter:
-        elements = soup.find_all(name, filter)
-    else:
-        elements = soup.find_all(name)
-    if elements:
-        for element in elements:
-            element.decompose()
+def _decompose_elements(soup, *element_kwargs):
+    elements = soup.find_all(*element_kwargs)
+    for element in elements:
+        element.decompose()
 
 
 def _remove_legislation_references(file_content):

--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -1,16 +1,18 @@
 import json
 import logging
 import re
-from typing import List
+from typing import Tuple
 
 from bs4 import BeautifulSoup
+
+from replacer.replacer_pipeline import replacer_pipeline
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
 
 
 def make_post_header_replacements(
-    original_content: str, post_header_replacement_content: str
+    original_content: str, replacement_patterns: str
 ) -> str:
     """
     Replaces the content following a closing header tag in a legal document with new content.
@@ -20,71 +22,62 @@ def make_post_header_replacements(
     - This function assumes a specific structure of the legal document with closing header tags.
 
     Args:
-        original_content (str): The original content of the legal document.
-        post_header_replacement_content (str): The replacement content to insert after the header.
+        original_content (str): The original content of the legal document
+        replacement_patterns (str): The line separated replacement patterns
 
     Returns:
         str: The modified legal document content with the replacement applied.
     """
     cleaned_file_content = sanitize_judgment(original_content)
-    document_split_by_header = split_text_by_closing_header_tag(cleaned_file_content)
-
-    post_header_content = document_split_by_header[2]
-
-    replaced_post_header_content = replace_text_content(
-        post_header_content, post_header_replacement_content
+    pre_header, end_header_tag, post_header = split_text_by_closing_header_tag(
+        cleaned_file_content
     )
+
+    replaced_post_header_content = apply_replacements(post_header, replacement_patterns)
     LOGGER.info("Got post-header replacement text content")
 
-    document_split_by_header[2] = replaced_post_header_content
-    full_replaced_text_content = "".join(document_split_by_header)
+    full_replaced_text_content = (
+        pre_header + end_header_tag + replaced_post_header_content
+    )
 
     return full_replaced_text_content
 
 
-def replace_text_content(file_content, replacements_content):
+def apply_replacements(content: str, replacement_patterns: str) -> str:
     """
     Run the replacer pipeline to make replacements on caselaw, legislation and abbreviations
     """
-    replacements = []
 
-    replacement_tuples_case = []
-    replacement_tuples_leg = []
-    replacement_tuples_abb = []
+    case_replacement_patterns = []
+    leg_replacement_patterns = []
+    abb_replacement_patterns = []
 
-    tuple_file = replacements_content
-    LOGGER.info("tuple_file")
-    LOGGER.info("---lines--")
+    for replacement_pattern_json in replacement_patterns.splitlines():
+        LOGGER.debug(replacement_pattern_json)
+        replacement_pattern_dict = json.loads(replacement_pattern_json)
 
-    for line in tuple_file.splitlines():
-        LOGGER.debug(line)
-        replacements.append(json.loads(line))
+        replacement_type, replacement_pattern_list = list(
+            replacement_pattern_dict.items()
+        )[0]
+        replacement_pattern = tuple(replacement_pattern_list)
 
-    for replacement in replacements:
-        key, value = list(replacement.items())[0]
+        if replacement_type == "case":
+            case_replacement_patterns.append(replacement_pattern)
 
-        LOGGER.info("replacements")
-        if key == "case":
-            case_law_tuple = tuple(replacement["case"])
-            replacement_tuples_case.append(case_law_tuple)
+        elif replacement_type == "leg":
+            leg_replacement_patterns.append(replacement_pattern)
 
-        elif key == "leg":
-            leg_tuple = tuple(replacement["leg"])
-            replacement_tuples_leg.append(leg_tuple)
-
-        else:
-            abb_tuple = tuple(replacement["abb"])
-            replacement_tuples_abb.append(abb_tuple)
-
-    from replacer.replacer_pipeline import replacer_pipeline
+        elif replacement_type == "abb":
+            abb_replacement_patterns.append(replacement_pattern)
 
     file_data_enriched = replacer_pipeline(
-        file_content,
-        replacement_tuples_case,
-        replacement_tuples_leg,
-        replacement_tuples_abb,
+        content,
+        case_replacement_patterns,
+        leg_replacement_patterns,
+        abb_replacement_patterns,
     )
-    LOGGER.info("Judgment enriched")
+
+    LOGGER.info("Content enriched")
 
     return file_data_enriched
 
@@ -137,13 +130,14 @@ def _remove_legislation_references(file_content):
     return file_content
 
 
-def split_text_by_closing_header_tag(file_content: str) -> List[str]:
+def split_text_by_closing_header_tag(content: str) -> Tuple[str, str, str]:
     """
-    Split file_content into start, closing header tag and body
+    Split content into start, closing header tag and body
     to ensure replacements only occur in the body.
     """
     header_patterns = [r"</header>", r"<header/>"]
     for pattern in header_patterns:
-        if pattern in file_content:
-            return re.split(f"({pattern})", file_content)
-    return ["", "", file_content]
+        if pattern not in content:
+            continue
+        return content.partition(pattern)
+    return "", "", content

--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -11,4 +11,4 @@ def split_text_by_closing_header_tag(file_content: str) -> List[str]:
     for pattern in header_patterns:
         if pattern in file_content:
             return re.split(f"({pattern})", file_content)
-    return [file_content]
+    return ["", "", file_content]

--- a/src/replacer/replacer_pipeline.py
+++ b/src/replacer/replacer_pipeline.py
@@ -57,7 +57,6 @@ def replacer_pipeline(
         file_data = replacer_caselaw(file_data, replacement)
 
     for replacement in list(set(REPLACEMENTS_LEG)):
-        print(replacement)
         file_data = replacer_leg(file_data, replacement)
 
     for replacement in list(set(REPLACEMENTS_ABBR)):

--- a/src/tests/fixtures/ewhc-ch-2023-257_original.xml
+++ b/src/tests/fixtures/ewhc-ch-2023-257_original.xml
@@ -1,0 +1,1984 @@
+<?xml version="1.0" encoding="utf-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="judgment">
+    <meta>
+      <identification source="#tna">
+	<FRBRWork>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/ewhc/ch/2023/257"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/ewhc/ch/2023/257"/>
+	  <FRBRdate date="2023-02-13" name="judgment"/>
+	  <FRBRauthor href="#ewhc-chancery-propertytrustsprobate"/>
+	  <FRBRcountry value="GB-UKM"/>
+	  <FRBRnumber value="257"/>
+	  <FRBRname value="Devon and Somerset Fire and Rescue Authority v Lee Howell &amp; Anor"/>
+	</FRBRWork>
+	<FRBRExpression>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/257"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/257"/>
+	  <FRBRdate date="2023-02-13" name="judgment"/>
+	  <FRBRauthor href="#ewhc-chancery-propertytrustsprobate"/>
+	  <FRBRlanguage language="eng"/>
+	</FRBRExpression>
+	<FRBRManifestation>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/257/data.xml"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/ch/2023/257/data.xml"/>
+	  <FRBRdate date="2023-02-12T18:47:49" name="transform"/>
+	  <FRBRauthor href="#tna"/>
+	  <FRBRformat value="application/xml"/>
+	</FRBRManifestation>
+      </identification>
+      <lifecycle source="#">
+	<eventRef date="2023-02-13" refersTo="#judgment" source="#"/>
+      </lifecycle>
+      <references source="#tna">
+	<TLCOrganization eId="ewhc-chancery-propertytrustsprobate" href="https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list" showAs="The Business and Property Courts (Property, Trusts and Probate List)" shortForm="The Property, Trusts and Probate List"/>
+	<TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives"/>
+	<TLCEvent eId="judgment" href="#" showAs="judgment"/>
+	<TLCPerson eId="devon-and-somerset-fire-and-rescue-authority-in-its-capacity-as-trustee-of-part-of-the-firefighters-pension-scheme-under-si-1992/129-firemen's-pension-scheme-order" href="" showAs="DEVON AND SOMERSET FIRE AND RESCUE AUTHORITY (in its capacity as trustee of part of the Firefighters Pension Scheme under SI 1992/129 Firemen's Pension Scheme Order)"/>
+	<TLCPerson eId="lee-howell" href="" showAs="LEE HOWELL"/>
+	<TLCPerson eId="the-commissioners-for-his-majestys-revenue-and-customs" href="" showAs="THE COMMISSIONERS FOR HIS MAJESTY’S REVENUE AND CUSTOMS"/>
+	<TLCRole eId="claimant" href="" showAs="Claimant"/>
+	<TLCRole eId="defendant" href="" showAs="Defendant"/>
+      </references>
+      <proprietary source="#">
+	<uk:court>EWHC-Chancery-PropertyTrustsProbate</uk:court>
+	<uk:year>2023</uk:year>
+	<uk:number>257</uk:number>
+	<uk:cite>[2023] EWHC 257 (Ch)</uk:cite>
+	<uk:parser>0.12.7</uk:parser>
+	<uk:hash>4e0236c837e6b38a42581eeb9d7ba059e9e39c629fe40bc1bba598f41d86b96d</uk:hash>
+      </proprietary>
+      <presentation source="#">
+	<html:style>
+#judgment { font-family: 'Times New Roman'; font-size: 12pt; }
+#judgment .Normal { font-size: 12pt; }
+#judgment .Heading1 { font-weight: bold; font-family: Arial; font-size: 16pt; }
+#judgment .Heading3 { font-weight: bold; font-family: Arial; font-size: 13pt; }
+#judgment .Heading5 { font-size: 12pt; color: #2F5496; }
+#judgment .CoverDesc { text-align: center; font-weight: bold; font-size: 18pt; }
+#judgment .CoverMain { font-weight: bold; text-decoration-line: underline; text-decoration-style: solid; font-size: 12pt; }
+#judgment .CoverText { text-align: right; text-decoration-line: underline; text-decoration-style: solid; font-size: 12pt; }
+#judgment .ParaHeading { font-size: 12pt; }
+#judgment .ParaLevel1 { text-align: justify; margin-left: 0.5in; font-size: 12pt; }
+#judgment .ParaLevel2 { text-align: justify; margin-left: 0.98in; font-size: 12pt; }
+#judgment .ParaLevel3 { text-align: justify; margin-left: 1.48in; font-size: 12pt; }
+#judgment .ParaLevel4 { text-align: justify; margin-left: 1.97in; font-size: 12pt; }
+#judgment .ParaLevel5 { text-align: justify; margin-left: 2.46in; font-size: 12pt; }
+#judgment .ParaLevel6 { text-align: justify; margin-left: 2.95in; font-size: 12pt; }
+#judgment .ParaLevel7 { text-align: justify; margin-left: 3.45in; font-size: 12pt; }
+#judgment .ParaLevel8 { text-align: justify; margin-left: 3.94in; font-size: 12pt; }
+#judgment .ParaLevel9 { text-align: justify; margin-left: 4.43in; font-size: 12pt; }
+#judgment .ParaNoNumber { text-align: justify; font-size: 12pt; }
+#judgment .Quote { text-align: justify; margin-left: 1in; margin-right: 1in; font-size: 12pt; }
+#judgment .Header { font-family: Univers; font-size: 12pt; }
+#judgment .Footer { font-family: Univers; font-size: 12pt; }
+#judgment .Heading { font-size: 12pt; }
+#judgment .Title { text-align: center; font-weight: bold; font-size: 10pt; }
+#judgment .eMailBlock { text-align: center; font-weight: bold; font-size: 13pt; }
+#judgment .ListParagraph { margin-left: 0.5in; font-size: 12pt; }
+#judgment .legclearfix { font-size: 12pt; }
+#judgment .legrhs { font-size: 12pt; }
+#judgment .leglisttextstandard { font-size: 12pt; }
+#judgment .NormalWeb { font-size: 12pt; }
+#judgment .Default { font-size: 12pt; color: #000000; }
+#judgment .FootnoteText { font-size: 10pt; }
+#judgment .Heading5Char { font-size: 12pt; color: #2F5496; }
+#judgment .legds { }
+#judgment .legchangedelimiter { }
+#judgment .Hyperlink { text-decoration-line: underline; text-decoration-style: solid; color: #0000FF; }
+#judgment .legsubstitution { }
+#judgment .legaddition { }
+#judgment .Emphasis { font-style: italic; }
+#judgment .UnresolvedMention { color: #605E5C; background-color: initial; }
+#judgment .HeaderChar { font-family: Univers; font-size: 12pt; }
+#judgment .FooterChar { font-family: Univers; font-size: 12pt; }
+#judgment .FootnoteTextChar { }
+#judgment .FootnoteReference { vertical-align: super; }
+#judgment .TableGrid { }
+#judgment .TableGrid td { border: 0.5pt solid; }
+</html:style>
+      </presentation>
+    </meta>
+    <header>
+      <p style="text-align:center"><img src="image1.png" style="width:76.3pt;height:75.6pt"/></p>
+      <p class="CoverText" style="text-align:left">Neutral Citation Number: <neutralCitation>[2023] EWHC 257 (Ch)</neutralCitation></p>
+      <p class="CoverText">Case No: <docketNumber>PT-2021-001060</docketNumber></p>
+      <p class="CoverMain"><courtType refersTo="#ewhc-chancery-propertytrustsprobate">IN THE HIGH COURT OF JUSTICE</courtType></p>
+      <p><courtType refersTo="#ewhc-chancery-propertytrustsprobate" style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid">BUSINESS AND PROPERTY COURTS OF ENGLAND AND WALES</courtType></p>
+      <p><courtType refersTo="#ewhc-chancery-propertytrustsprobate" style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid">PROPERTY, TRUSTS AND PROBATE LIST (ChD)</courtType></p>
+      <p class="CoverText">Rolls Building,</p>
+      <p class="CoverText"><span> </span><span style="color:#000000;background-color:#FFFFFF">7 Rolls Building, Fetter Lane</span><br/><span style="color:#000000;background-color:#FFFFFF">London EC4A 1NL</span></p>
+      <p class="CoverText">Date: <docDate date="2023-02-13" refersTo="#judgment">13/02/2023</docDate></p>
+      <p style="text-align:center"><span style="font-weight:bold">Before</span> :</p>
+      <p class="CoverMain" style="text-align:center">HH JUDGE DAVIS-WHITE KC </p>
+      <p class="CoverMain" style="text-align:center">(SITTING AS A JUDGE OF THE CHANCERY DIVISION)</p>
+      <p style="text-align:center">- - - - - - - - - - - - - - - - - - - - -</p>
+      <p style="text-align:center"><span style="font-weight:bold">Between :</span></p>
+      <table uk:widths="1.23in 3.87in 1.24in">
+	<tr>
+	  <td>
+	    <p/>
+	  </td>
+	  <td>
+	    <p style="text-align:center"><party refersTo="#devon-and-somerset-fire-and-rescue-authority-in-its-capacity-as-trustee-of-part-of-the-firefighters-pension-scheme-under-si-1992/129-firemen's-pension-scheme-order" as="#claimant" style="font-weight:bold"> DEVON AND SOMERSET FIRE AND RESCUE AUTHORITY (in its capacity as trustee of part of the Firefighters Pension Scheme under SI 1992/129 Firemen's Pension Scheme Order)</party></p>
+	  </td>
+	  <td>
+	    <p class="CoverMain" style="text-align:right"/>
+	    <p class="CoverMain" style="text-align:right"/>
+	    <p class="CoverMain" style="text-align:right"/>
+	    <p class="CoverMain" style="text-align:right"><role refersTo="#claimant">Claimant</role></p>
+	  </td>
+	</tr>
+	<tr>
+	  <td>
+	    <p/>
+	  </td>
+	  <td>
+	    <p style="text-align:center"><span style="font-weight:bold">- and -</span></p>
+	  </td>
+	  <td>
+	    <p class="CoverMain" style="text-align:right"/>
+	  </td>
+	</tr>
+	<tr>
+	  <td>
+	    <p/>
+	  </td>
+	  <td>
+	    <blockContainer>
+	      <num style="font-weight:bold;margin-left:0.5in;text-indent:-0.25in">(1)</num>
+	      <p style="text-align:center;margin-left:0.5in;text-indent:0.12in"><party refersTo="#lee-howell" as="#defendant" style="font-weight:bold">LEE HOWELL</party></p>
+	    </blockContainer>
+	    <blockContainer>
+	      <num style="font-weight:bold;margin-left:0.5in;text-indent:-0.25in">(2)</num>
+	      <p style="text-align:center;margin-left:0.5in;text-indent:0.12in"><party refersTo="#the-commissioners-for-his-majestys-revenue-and-customs" as="#defendant" style="font-weight:bold">THE COMMISSIONERS FOR HIS MAJESTY’S REVENUE AND CUSTOMS</party></p>
+	    </blockContainer>
+	  </td>
+	  <td>
+	    <p class="CoverMain" style="text-align:right"/>
+	    <p class="CoverMain" style="text-align:right"/>
+	    <p class="CoverMain" style="text-align:right"><role refersTo="#defendant">Defendants</role></p>
+	  </td>
+	</tr>
+      </table>
+      <p style="text-align:center">- - - - - - - - - - - - - - - - - - - - -</p>
+      <p style="text-align:center">- - - - - - - - - - - - - - - - - - - - -</p>
+      <p style="text-align:center"><span style="font-weight:bold">Ms Harriet Brown </span>(instructed by<span style="font-weight:bold"> Plymouth City Council Legal Services</span>) for the Claimant</p>
+      <p style="text-align:center"><span style="font-weight:bold">Mr Simon Oakes </span>(instructed by <span style="font-weight:bold">HMRC Solicitor’s Office &amp; Legal Services</span>) for the Second Defendant</p>
+      <p style="text-align:center">The First Defendant did not appear and was not represented</p>
+      <p style="text-align:center">Hearing dates: 23 (Reading), 24-26 January 2023</p>
+      <p style="text-align:center">- - - - - - - - - - - - - - - - - - - - -</p>
+      <p class="CoverDesc">Approved Judgment</p>
+      <p style="text-align:center">I direct that pursuant to CPR PD 39A para 6.1 no official shorthand note shall be taken of this Judgment and that copies of this version as handed down may be treated as authentic.</p>
+      <p style="text-align:center">.............................</p>
+      <p style="text-align:center">HH JUDGE DAVIS-WHITE KC (SITTING AS A JUDGE OF THE CHANCERY DIVISION)</p>
+      <p>This judgment was handed down by the Judge remotely by circulation to the parties' representatives by email and release to The National Archives. The date and time for hand-down is deemed to be 10:30am on 13 February 2023/</p>
+      <table class="TableGrid" uk:widths="6.26in">
+	<tr>
+	  <td style="border:0.5pt solid">
+	    <block name="restriction" style="text-align:justify"><span style="font-weight:bold">If this Transcript is to be reported or published, there is a requirement to ensure that no reporting restriction will be breached. This is particularly important in relation to any case involving a sexual offence, where the victim is guaranteed lifetime anonymity (Sexual Offences (Amendment) Act 1992), or where an order has been made in relation to a young person</span></block>
+	  </td>
+	</tr>
+	<tr>
+	  <td style="border:0.5pt solid">
+	    <p><span style="font-weight:bold">This Transcript is Crown Copyright.  It may not be reproduced in whole or in part other than in accordance with relevant licence or with the express consent of the Authority.  All rights are reserved.</span></p>
+	  </td>
+	</tr>
+      </table>
+    </header>
+    <judgmentBody>
+      <decision>
+	<level>
+	  <content>
+	    <p><span style="font-weight:bold">HH Judge Davis-White KC :</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_1">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">1.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The trial before me of the Part 8 claim form in this matter concerns a short point of statutory construction.  Put broadly, it is whether one of the conditions for transitional tax relief under the Finance Act 2004 applies in the circumstances of this case to a pension that the First Defendant would like to take under the pension scheme that applies to him.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_2">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">2.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Claimant is the Devon and Somerset Fire and Rescue Authority (the “Claimant” or the “Fire Authority”). It is a body corporate established by The Devon and Somerset Fire and Rescue Authority (Combination Scheme) Order 2006 (SI/No 2790 of 2006).  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_3">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">3.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Fire Authority is also a relevant “fire and rescue authority” for the purposes of the Firemen’s Pension Scheme Order 1992 (SI No. 129 of 1992) (the “FPSO”).  The FPSO, in broad terms, sets up a pension scheme for the benefit of (among others) “fire fighters, their spouses and civil partners and dependents” (see FPSO, Schedule 2,  rule A3(1)) (the “Scheme”).   The Scheme is set out in Schedule 2 to FPSO.  For the remainder of this judgment, I refer to the relevant rules of the Scheme by reference to FPSO without necessarily identifying the schedule of FPSO.  The Fire Authority has various responsibilities, duties and discretions under the Rules in FPSO.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_4">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">4.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Although described before me and in the heading to the court documents as “trustee” there is a dispute between the parties as to whether the Fire Authority is a trustee of the Scheme in the true sense of that term.  On the limited material before me and submissions made to me, there is a real question as to whether the Fire Authority actually holds any trust property (rather than making records in its books of account as to sums received and sums expended in relation to the Scheme).  As I go on to explain, that is but one dispute among a number that I do not consider that I need to resolve for the purposes of determining the real matter in issue between the parties.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_5">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">5.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Fire Authority was represented before me by Ms Harriet Brown.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_6">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">6.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Fire Authority employs the First Defendant, Mr Lee Howell. He is currently the Chief Fire Officer of the Authority. It is accepted that the Scheme applies to him.  The question before me concerns the application of relevant transitional provisions of the Finance Act 2004 to his pension rights under his employment contract and the terms of FPSO.  The question of transitional provisions arises because the Finance Act 2004 raised the age at which pensions could be taken on retirement without losing certain favourable tax conditions. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_7">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">7.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Mr Howell was present in court to observe the hearing before me but was not represented and did not formally take part in the hearing.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_8">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">8.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Second Defendant, the Commissioners for His Majesty’s Revenue, were represented by Mr Simon Oakes. For convenience I refer to them in this judgment as “HMRC”.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_9">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">9.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I am grateful to Ms Brown and Mr Oakes for their helpful submissions, both oral and written. Ms Brown provided two skeleton arguments and a written note. Mr Oakes also provided two skeleton arguments.</p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold">The issue</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_10">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">10.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Before turning to the specific facts relating to Mr Howell’s position, it is necessary to explain the relevant terms of the Finance Act 2004 and the relevant terms of FPSO.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_11">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">11.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Finance Act 2004 (“FA 2004”) had the effect of simplifying the favourable tax regime applicable to pensions.  A number of separate tax regimes for different types of scheme were brought within the umbrella of one type of scheme, the “registered” pension scheme.  In particular, under the FA 2004 “registered” pension schemes are subject to a favourable tax regime.  The FA 2004 also incorporates the concept of <span style="font-family:'Times New Roman';color:#0B0C0C;background-color:#FFFFFF">the normal minimum pension age (</span><span style="font-family:'Times New Roman'">NMPA</span><span style="font-family:'Times New Roman';color:#0B0C0C;background-color:#FFFFFF">), which is the minimum age at which most pension savers can access their pensions without incurring an unauthorised payments tax charge, unless they are retiring due to ill-health.  The </span><span style="font-family:'Times New Roman'">NMPA</span><span style="font-family:'Times New Roman';color:#0B0C0C;background-color:#FFFFFF"> took effect in April 2006.  It was increased from age 50 to age 55 with effect from 2010. It will increase to age </span><span style="font-family:'Times New Roman';color:#202124;background-color:#FFFFFF">57 (for most persons) on 6 April 2028. The increase to age 57 will not apply to members of the various firefighters, police and armed forces public service pension schemes (commonly referred to as uniformed services pension schemes).  Each increase has sought to protect certain rights accrued before the date from which the minimum age increases.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_12">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">12.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The question in this case is whether in April 2006, Mr Howell had relevant rights which are protected under the transitional provisions contained in Schedule  FA 2004.  If his rights are protected then payment of his pension may be made to him without suffering tax charges.  If they are not protected then a number of tax charges may arise if he receives pension payments before the age of 55.</p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold">Relevant provisions of the Finance Act 2004</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_13">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">13.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The starting point is that under section 160 FA 2004, the only payments which a registered pension scheme is authorised to make to, or in respect of a member of the scheme, are those specified in section 164 FA 2004.  In the extracts from the FA 2004 that I set out in this judgment, I have indicated amendments made by square brackets.  I am satisfied that the changes made do not affect or assist in the exercise of statutory interpretation that I have to carry out.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_14">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">14.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Sections 160(1) and (2) FA 2004 (as amended) provide:-</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-style:italic;font-weight:bold;font-family:Arial;font-size:9.5pt;color:#000000">“160</num>
+	    <intro>
+	      <p class="Heading5" style="margin-left:0.39in;text-indent:0.5in"><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">Payments by registered pension schemes</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman';color:#000000">(1)</num>
+	      <content>
+		<p style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">The only payments which a registered pension scheme is authorised to make to or in respect of a </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">person who is or has been a</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000"> member of the pension scheme are those specified in section 164.</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-style:italic;font-family:'Times New Roman';color:#000000">(2)</num>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.5in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">In this Part “unauthorised member payment” means—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  a payment by a registered pension scheme to or in respect of a </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">person who is or has been a</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000"> member of the pension scheme which is not authorised by section 164, and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  anything which is to be treated as an unauthorised payment to or in respect of a </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">person who is or has been a</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000"> member of the pension scheme under </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">this Part</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">.”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_15">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">15.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Section 164(1) FA 2004 (as amended) provides:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.79in"><span style="font-family:'Times New Roman'">““</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">164  Authorised member payments</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">[(1)]</span><marker name="tab"/><span style="font-style:italic;font-family:'Times New Roman';color:#000000">The only payments a registered pension scheme is authorised to make to or in respect of a [person who is or has been a] member of the pension scheme are—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  pensions permitted by the pension rules or the pension death benefit rules [to be paid to or in respect of a member] (see sections 165 and 167),</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  lump sums permitted by the lump sum rule or the lump sum death benefit rule [to be paid to or in respect of a member] (see sections 166 and 168),</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(c)  recognised transfers (see section 169),</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(d)  scheme administration member payments (see section 171),</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(e)  payments pursuant to a pension sharing order or provision, and</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(f)   payments of a description prescribed by regulations made by the Board of Inland Revenue.”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_16">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">16.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As I have said, the FA 2004, raised the minimum normal pension age from 50 to 55. Section 165 FA 2004 provides a number of “pension rules”. As regards this case, the first pension rule is the relevant one.  In this respect, section 165 FA 2004 provides:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-family:'Times New Roman'">“165</num>
+	    <intro>
+	      <p class="Heading5" style="margin-left:0.39in;text-indent:0.5in"><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">Pension rules</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:1.04in;text-indent:-0.25in">(1)</num>
+	      <content>
+		<p class="ListParagraph" style="margin-left:1.04in;text-indent:0.12in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000"> These are the rules relating to the payment of pensions by a registered pension scheme to a member of the pension scheme (“the pension rules”).</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <intro>
+		<p style="text-align:justify;margin-left:0.64in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">Pension rule 1</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p style="text-align:justify;margin-left:1.04in;text-indent:0.04in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">No payment of pension may be made before the day on which the member reaches normal minimum pension age, unless the ill-health condition was met immediately before the member became entitled to a pension under the pension scheme.”</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_17">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">17.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Normal minimum pension age is defined by section 279(1)) FA 2004 as follows:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-family:'Times New Roman'">“279</num>
+	    <intro>
+	      <p class="Heading5" style="margin-left:0.11in;text-indent:0.79in"><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">Other definitions</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:1.04in;text-indent:-0.25in">(1)</num>
+	      <content>
+		<p class="ListParagraph" style="margin-left:1.04in;text-indent:0.12in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000"> In this Part—</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <intro>
+		<p style="text-align:justify;margin-left:0.64in;text-indent:0.39in"><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">“normal minimum pension age” means—</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p style="text-align:justify;margin-left:1.04in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(a) in relation to, and to a member of, a pension scheme that is not a uniformed services pension scheme—</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:0.89in;text-indent:0.29in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(i)   before 6 April 2010, 50,</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:0.89in;text-indent:0.29in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(ii)  on and after that date but before 6 April 2028, 55, and</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<intro>
+		  <p style="margin-left:0.89in;text-indent:0.29in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(iii)  on and after 6 April 2028, 57, and</span></p>
+		</intro>
+		<subparagraph>
+		  <content>
+		    <p style="margin-left:1.08in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(b) in relation to, and to a member of, a uniformed services pension scheme—</span></p>
+		  </content>
+		</subparagraph>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:0.89in;text-indent:0.29in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(i)</span><marker name="tab"/><span style="font-style:italic;font-family:'Times New Roman';color:#000000">before 6 April 2010, 50, and</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:0.89in;text-indent:0.29in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(ii)</span><marker name="tab"/><span style="font-style:italic;font-family:'Times New Roman';color:#000000">on and after that date, 55,</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<intro>
+		  <p style="margin-left:0.89in"><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(4)   In this section “uniformed services pension scheme” means a pension scheme that—</span></p>
+		</intro>
+		<subparagraph>
+		  <content>
+		    <p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  is established by or under an enactment or Royal Warrant for the benefit of persons described in subsection (5) (whether or not other persons may be members of such a scheme), or</span></p>
+		  </content>
+		</subparagraph>
+		<subparagraph>
+		  <content>
+		    <p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  is established solely for the receipt of additional voluntary contributions from members of a scheme falling within paragraph (a),</span></p>
+		  </content>
+		</subparagraph>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="text-align:justify;margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">subject to any regulations made under subsection (6).</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman';color:#000000">(5)</num>
+	      <intro>
+		<p style="margin-left:0.39in;text-indent:0.5in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">Those persons are persons who are or were—</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  members of the naval, military or air forces of the Crown (including members of any reserve force);</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  members of a police force other than the Civil Nuclear Constabulary;</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman';color:#000000">(c)  firefighters.”</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_18">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">18.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In the event that a pension payment is made that is not “authorised”, then unfavourable tax consequences follow. Under section 208 FA 2004 an unauthorised payments charge, being a charge to income tax of 40% on the payment falling on the recipient of the payment, will arise.  Under sections 209-210 FA 2004, an unauthorised payments surcharge of 15% may arise, chargeable to the recipient of the relevant payment. The surcharge arises on a calculated basis depending on the proportion that the unauthorised payments made within a specified period bear to the member’s “crystallised” and “uncrystallised” rights (in each case valued according to a methodology set out in the FA 2004). Finally, under sections 239 and following sections a scheme sanction charge, being a charge to income tax, may fall on the scheme administrator where in any tax year one or more scheme chargeable payments are made by a registered scheme. There are other potential consequences of making unauthorised payments under section 242 FA 2004.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_19">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">19.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As I shall go on to explain, Mr Howell now wishes to take his pension under FPSO before the age of 55.  The Claimant is not prepared to pay such a pension if it is “unauthorised” such that payment would raise the reality or possibility of the unfavourable tax consequences of such an unauthorised payment. The question is therefore whether the transitional provisions set out in Schedule 36 apply so as to prevent this consequence.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_20">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">20.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Section 160(9) FA 2004 refers in terms to transitional provisions being contained in Schedule 36 parts 3 and 4. Section 283 FA 2004 also provides that Schedule 36 contains various transitional and savings provisions.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_21">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">21.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Schedule 36 to the FA 2004, Part 3 deals with the position of “Pre-commencement benefit rights”.  Paragraph 21 provides (among other things) that if paragraph 21 applies in relation to a registered pension scheme and a member of the pension scheme, then save in respect of two provisions, the relevant part of the 2004 Act containing the provisions that I have dealt with, has effect as if references to “normal minimum pension age” were references to “the member’s protected pension age”.  Where the relevant conditions spelled out in paragraph 21 apply, then the member’s protected pension age is the age from which the member had “an actual or prospective right to any benefit under the protected pension scheme on 5 April 2006, or, where condition B is met, under the original pension scheme on that date” (see paragraph 22(8)). However the paragraph does not operate so as to give the member a protected pension age of more than 50 at any time before 6 April 2010 (see paragraph 22(9)).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_22">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">22.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The pension sought to be taken by Mr Howell in this case is one that he seeks payment of before he attains the age of 55. For convenience I refer to this as an “early pension”, meaning a pension taken before what would be the normal minimum pension age, for him, of 55 years.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_23">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">23.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in"> As will be seen, paragraph 22 will apply where a pension scheme is a “protected pension scheme” and “the retirement condition is met in relation to the member and the pension scheme” (paragraph 22(1). </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_24">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">24.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">To be a “protected pension scheme”, conditions A or B have to be met (paragraph 22(2)).  Condition B does not apply in this case. It relates to block transfers between pension schemes.  Condition A requires two conditions to be met. The first is that the pension scheme falls within any of the categories of pension scheme which became registered pension schemes on 6 April 2006 as set out in paragraph 1(1) of the Schedule.  That condition is met here. The second condition is that “the entitlement condition” is met in relation to the member and the pension scheme (paragraph 22(3)).  The “entitlement condition” contains three elements: (a) on 5 April 2006, the member must have had an “actual or prospective right under the pension scheme to any benefit from an age of less than 55” ; (b) the rules of the pension scheme on 10 December 2003, must have included provision conferring such a right on some or all of the persons who were then members of the scheme and (c) such a right must then have been conferred on the member or would have been if he or she had been a member of the scheme on that date.  It is condition (a) of the entitlement  condition which arises in this case and where there is a dispute as to whether it does or does not apply.  Elements (b) and (c) of the entitlement condition are met in this case.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_25">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">25.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As regards the “retirement condition”, there is a dispute as to whether I should make any determination as to the construction of the relevant paragraphs or their effect in the current factual situation.  Two conditions apply.  First the member must become entitled to all the benefits payable to him (or her) under arrangements under the scheme (to which he did not have actual entitlement on or before 5 April 2006) on the same date.  Secondly, in a case where on 5 April 2006 the member had an actual or prospective right under the pension scheme to any benefit from an age of less than 50, condition 1 must be met or, in any other case, condition 2 or 3 must be met. Conditions 1 to 3 relate to requirements that the member is not employed by certain types of employer after he or she becomes entitled to all the relevant benefits and that the becoming entitled to the benefits must not be a part of an arrangement the main, or one of the main purposes, is to avoid tax or national insurance contributions.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_26">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-family:'Times New Roman';font-size:12pt;margin-left:0.5in;text-indent:-0.5in">26.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in"><span style="font-family:'Times New Roman'">Paragraph 22 of Schedule 36 provides as follows. I have put in bold the main provision which was in issue before me:</span></p>
+	  </intro>
+	  <subparagraph>
+	    <num class="legds" style="font-family:'Times New Roman';color:#000000">“22(1)</num>
+	    <content>
+	      <p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">This paragraph applies in relation to a registered pension scheme and a member of the pension scheme if—</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  the pension scheme is a protected pension scheme, and</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  the retirement condition is met in relation to the member and the pension scheme.</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(2)</num>
+	    <content>
+	      <p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">A pension scheme is a protected pension scheme if condition A or condition B is met.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(3)</num>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.5in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">Condition A is met if—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  the pension scheme was within any of paragraphs (a) to (e) of paragraph 1(1), and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  the entitlement condition is met in relation to the member and the pension scheme.</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(4)</num>
+	      <intro>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">The entitlement condition is met in relation to the member and the pension scheme if—</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">(a)  on 5th April 2006 the member had an actual or prospective right under the pension scheme to </span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legsubstitution" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">any benefit</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span class="legds" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000"> from an age of less than 55,</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  the rules of the pension scheme on 10th December 2003 included provision conferring such a right on some or all of the persons who were then members of the pension scheme, and</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(c)  such a right either was then conferred on the member or would have been had the member been a member of the scheme on that date.</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	    <subparagraph>
+	      <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(5)</num>
+	      <intro>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">Condition B is met if the member is a member of the pension scheme </span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">(“a transferee pension scheme”) as a result of—</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  a block transfer from the pension scheme (“the original pension scheme”) in relation to which condition A is met to the transferee pension scheme, or</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  a block transfer to the transferee pension scheme from a pension scheme that was a transferee pension scheme in relation to the original pension scheme by virtue of the previous application of paragraph (a) or the previous application (on one or more occasions) of this paragraph.</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(6)</num>
+	    <content>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.5in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">A transfer is a block transfer if….</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(6A)  A transfer is also a block transfer if…</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7)</num>
+	      <intro>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">The retirement condition is met in relation to the member and the pension scheme if—</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  the member becomes entitled to all the </span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">benefits</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000"> payable to the member under arrangements under the pension scheme (to which the member did not have an actual entitlement on or before 5th April 2006) on the same date, and</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  in a case where on 5th April 2006 the member had an actual or prospective right under the pension scheme to any benefit from an age of less than 50, Condition 1 is met or, in any other case, Condition 2 or 3 is met.</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7A)  Condition 1 is met if—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a) the member is not, after becoming entitled to the benefits mentioned in sub-paragraph (7)(a), employed by a person who is a sponsoring employer in relation to the pension scheme and with whom the member is connected, and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  the member's becoming entitled to those benefits is not part of an arrangement the main purpose (or one of the main purposes) of which is the avoidance of tax or national insurance contributions.</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7B)  Condition 2 is met if—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  the member is not, after becoming entitled to the benefits mentioned in sub- paragraph (7)(a), employed by a person specified in sub-paragraph (7C), and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  the member's becoming entitled to those benefits is not part of an arrangement the main purpose (or one of the main purposes) of which is the avoidance of tax or national insurance contributions.</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7C)  The persons referred to in sub-paragraph (7B)(a) are—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  any person who was a sponsoring employer in relation to the pension scheme at any time during the period of six months ending with the day on which the member became entitled to the benefits mentioned in sub-paragraph (7)(a) and by whom the member was employed at any time during that period,</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <intro>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  any person who is connected with any such person, or</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(c)  any person who is a sponsoring employer in relation to the pension scheme and with whom the member is connected.</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7D)  If the member has become entitled to the benefits payable under arrangements under the pension scheme by reason of service in the armed forces of the Crown, any employment on compulsory recall is to be disregarded for the purposes of sub-paragraph (7B)(a).</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7E)  Condition 3 is met if —</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  paragraph (a) of sub-paragraph (7B) is not satisfied but one of the re-employment conditions is met, and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  paragraph (b) of that sub-paragraph is satisfied.</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7F)  The re-employment conditions are—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  that the member is not employed as mentioned in sub-paragraph (7B)(a) during the period of six months beginning with the day on which the member becomes entitled to the benefits mentioned in sub-paragraph (7)(a), and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  that the member is not employed as mentioned in sub-paragraph (7B)(a) during the period of one month beginning with that day, but is so employed during the period of five months beginning at the end of that period, and either the pension abatement condition or the materially different employment condition is met </span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[,</span><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000"> and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <intro>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(c)  that the member is or was employed as mentioned in sub-paragraph (7B)(a) where—</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.58in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(i)   the employment began at any time during the coronavirus period, and</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.58in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(ii)  the only or main reason that the member was taken into employment was to help the employer to respond to the public health, social, economic or other effects of coronavirus.</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7G)  The pension abatement condition is met if—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <intro>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  the pension scheme is a public service pension scheme, and</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  the member's benefits under the scheme consist of or include a scheme pension which is liable to reduction by abatement while the member is employed as mentioned in sub-paragraph (7B)(a) and is under the age of 55.</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7H)  The materially different employment condition is met—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  in a case where the member is employed as mentioned in sub-paragraph (7B)(a) in more than one employment during the period of five months mentioned in sub-paragraph (7F)(b), if each of those employments, and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  otherwise, if the employment in which the member is so employed during that period, is materially different in nature from the employment in which the member was employed immediately before becoming entitled to the benefits mentioned in sub-paragraph (7)(a).</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7I)  For the purposes of sub-paragraph (7D) “employment on compulsory recall” means permanent service—</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(a)  under Part 4 of the Reserve Forces Act 1996,</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(b)  under Part 5 of that Act,</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <intro>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(c)  under a call-out or recall order made under that Act,</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="legclearfix" style="margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(d)  having been called out or recalled under the Reserve Forces Act 1980, or</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.39in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(e)  because of any other call-out or recall obligation of an officer.</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7J)  </span><span class="legchangedelimiter" style="font-style:italic;font-family:'Times New Roman';color:#000000">[S</span><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">ection 1122 of the Corporation Tax Act 2010</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000"> (connected persons) applies for the purposes of this paragraph.</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p class="legclearfix" style="margin-left:0.39in;text-indent:0.39in"><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7K)  In sub-paragraph (7F)(c)—</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="leglisttextstandard" style="text-align:justify;margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">“coronavirus” has the same meaning as in the Coronavirus Act 2020 (see section 1(1) of that Act);</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="leglisttextstandard" style="text-align:justify;margin-left:1.18in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">“the coronavirus period” means the period beginning with 1 March 2020 and ending with 1 November 2020.</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7L)  The Treasury may by regulations amend the definition of “the coronavirus period” in sub-paragraph (7K) so as to replace the later of the dates specified in it with another date falling before 6 April 2021.</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in"><span class="legaddition" style="font-style:italic;font-family:'Times New Roman';color:#000000">(7M)  The power in sub-paragraph (7L) may be exercised on more than one occasion.</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(8)</num>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">The member’s protected pension age is the age from which the member had an actual or prospective right to </span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">[</span><span class="legsubstitution" style="font-style:italic;font-family:'Times New Roman';color:#000000">any benefit</span><span class="legchangedelimiter" style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#000000">]</span><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000"> under the protected pension scheme on 5th April 2006 (or, where condition B is met, under the original pension scheme on that date).</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">(9)</num>
+	      <content>
+		<p class="legclearfix" style="margin-left:0.79in;text-indent:0.21in"><span class="legds" style="font-style:italic;font-family:'Times New Roman';color:#000000">But this paragraph does not have effect so as to give the member a protected pension age of more than 50 at any time before 6th April 2010.”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="legclearfix"><span class="legds" style="font-weight:bold;font-family:'Times New Roman';color:#000000">Relevant Provisions of Firemen’s Pension Scheme Order 1992</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_27">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">27.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The immediately relevant provisions of FPSO<authorialNote class="footnote" marker="1">
+		<p class="FootnoteText"> Applicable in England. There are now different provisions of the SI applying to each of England, Scotland and Wales.</p>
+	      </authorialNote> that I was referred to as applying to Mr Howell are those of the pension scheme itself as set out in Schedule 2 to the statutory instrument.  They were A3 (dealing with the persons to whom the Scheme applies), A13 (setting out the normal pension age of 55) and B1 setting out an entitlement to take an ordinary pension at the age of 50 (calculated in accordance with Part 1 of Schedule 2) in certain cases of long service. That entitlement will not apply in certain circumstances whose existence can only be determined in connection with or at or shortly before actual retirement. For present purposes, the key condition is that the entitlement to a pension at the age of 50 will not apply to a Chief Fire Officer, if the Chief Fire Officer retires before the age of 55, unless notice of retirement was given with the permission of the fire and rescue authority.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_28">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">28.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The short issue is whether or not any such entitlement of the CFO prior to notice of retirement being given is, as Ms Brown submits, an “actual” or “prospective” right to such benefit within the meaning of paragraph 22 of Schedule 36 FA 2004 or, as Mr Oakes submits, neither an “actual” nor a “prospective” right because it is dependent on a third party giving a relevant consent or permission before the right to a pension can come into being, such consent/permission being that of the claimant to the relevant notice of retirement being given. In what follows, the extracts from FPSO are those in force as at 5 April 2006.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_29">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">29.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The issue is whether or not relevant rights were held by Mr Howell as at 6 April 2006 and therefore the version of the statutory instrument that applied at that time to Mr Howell. In what follows I have used the version said to ave been in force by Westlaw which also shows, by square brackets amendments from the SI as originally enacted.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_30">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">30.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">A3 of Schedule 2 to FPOS provided:</p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p class="NormalWeb" style="margin-left:0.39in;text-indent:0.39in"><span class="Emphasis" style="font-weight:bold;font-family:'Times New Roman';color:#333335">“A3 Exclusive application to regular firefighters</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="NormalWeb" style="margin-left:0.79in"><span class="Emphasis" style="font-family:'Times New Roman';color:#333335">(1)</span><span style="font-style:italic;font-family:'Times New Roman';color:#333335">    </span><span style="font-style:italic">Subject to [paragraphs (3) and (4)] , this Scheme applies in relation to regular firefighters and their spouses [ or civil partners] and dependants to the exclusion of pension provision under any enactment other than section 26 of the principal Act and the Social Security Act 1975. </span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic">(2)</num>
+	      <content>
+		<p class="NormalWeb" style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic">In paragraph (1) “pension provision” means any provision for the payment of a pension, allowance or gratuity, on cessation of employment or on death, in respect of employment as a regular firefighter. </span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic">(3)</num>
+	      <content>
+		<p class="NormalWeb" style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic">A person who is not [an employee of a fire and rescue authority] but whose employment is, under rule A4 or A5, treated for the purposes of this Scheme as employment as a regular firefighter is not a regular firefighter for the purposes of this rule.</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="NormalWeb" style="margin-left:0.79in"><span style="font-style:italic">[ (4) Nothing in this rule prevents provision being made by this Scheme in respect of pension credit members. ] A13 of Schedule 2 to FPOS provides:</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_31">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">31.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">A13 of Schedule 2 to FPOS provided:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="NormalWeb" style="margin-left:0.79in"><span style="font-style:italic">“[A13. </span><span style="font-style:italic;font-weight:bold">Normal pension age</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p class="NormalWeb" style="margin-left:0.79in"><span style="font-style:italic">The normal pension age of employees of a fire and rescue authority appointed on terms under which they are or may be required to engage in fire-fighting is 55.]</span>”</p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_32">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">32.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">B1 of Schedule 2 to FPOS provided:</p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p class="NormalWeb" style="margin-left:0.39in;text-indent:0.39in"><span style="font-family:'Times New Roman'">“</span><span style="font-style:italic">B1.— Ordinary pension </span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-style:italic">(1)</num>
+	      <content>
+		<p class="NormalWeb" style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic">Subject to paragraph (2), this rule applies to a regular firefighter who retires if he then— </span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <intro>
+		<p class="NormalWeb" style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic">(a) has attained the age of 50, and </span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="NormalWeb" style="margin-left:1.18in"><span style="font-style:italic">(b) is entitled to reckon at least 25 years' pensionable service, and (c) does not become entitled to an ill-health award under rule B3. </span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic">(2)</num>
+	      <intro>
+		<p class="NormalWeb" style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic">This rule does not apply— </span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="NormalWeb" style="margin-left:1.18in"><span style="font-style:italic">(a) to a person whose notice of retirement states that he is retiring for the purpose of [taking up employment with another fire and rescue authority], or </span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="NormalWeb" style="margin-left:1.18in"><span style="font-style:italic">(b) unless his notice of retirement was given with the permission of the [fire and rescue authority], to a [chief fire officer]…. who retires before attaining the age of 55, or </span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="NormalWeb" style="margin-left:1.18in"><span style="font-style:italic">(c) where immediately before the person's retirement an election under rule G3 not to pay pension contributions had effect. </span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic">(3)</num>
+	      <content>
+		<p class="NormalWeb" style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic">A person to whom this rule applies becomes entitled on retiring to an ordinary pension calculated in accordance with Part I of Schedule 2.” </span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in;text-indent:-0.5in"><span style="font-weight:bold">The Facts</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_33">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">33.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Unfortunately, the parties were unable to agree, as directed, a statement of facts and issues.  Somewhat unusually, the parties rather than awaiting or seeking a relevant court order, decided that they would adopt the route of having “particulars of claim” and a defence (rather than, if ordered by the court, points of claim and points of defence) in these part 8 proceedings.  The status of these statements of case is somewhat uncertain.  Written witness evidence was served and HMRC agreed that there should be no cross-examination nor any disclosure.  In its defence, HMRC in large point put the claimant to proof of the facts as pleaded.  In reaching trial, HMRC sought to maintain the position that certain of the facts were not proved but that HMRC was prepared to accept the facts for the purposes of the hearing before me only.   </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_34">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">34.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In my judgment, HMRC’s initial stance regarding the facts was misguided.  This was the trial of the Part 8 claim.  There was written evidence filed.  If not contested then the facts set out in that witness evidence would be facts that the court would be able to, and would be likely to, find.  Once those facts were found they would bind HMRC and the other parties, not just for the hearing but thereafter.  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_35">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">35.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I understood Mr Oakes ultimately to accept:-</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(1)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in">that in the material respects set out below, there was uncontested evidence before me justifying the findings of fact which I set out below.</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(2)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in">that in reality HMRC were contesting the construction put upon the FA 2004 relied upon by the Claimant and/or some of the asserted facts put forward by Ms Brown without any supporting evidence.</p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_36">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">36.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">However, Ms Brown was also not prepared to agree certain facts that HMRC wished to rely upon.  Again, when tested, Ms Brown ultimately accepted (as I understood it) that the relevant facts set out below were either agreed or that it was open to me on the evidence to make findings of fact regarding the same and that her client ultimately did not dispute the same.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_37">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-family:'Times New Roman';font-size:12pt;margin-left:0.5in;text-indent:-0.5in">37.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in"><span style="font-family:'Times New Roman'">The key facts that I find as applying in this case are therefore as follows. They are in part taken from a draft statement of facts that the parties were unable to agree and in part from the evidence before me, most pertinently, a witness statement of Mr Michael Pearson (“Mr Pearson”) dated 18 November 2021.  Mr Pearson has been employed by the Fire Authority since 2007 and is currently its Director of Governance and Digital Services. He is also the Clerk to the Authority and the Monitoring Officer.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_38">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">38.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The Scheme is a registered pension scheme and a public service pension scheme under the FA 2004, section 150(2) and 150(3) respectively. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_39">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">39.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Firefighters employed by local authorities are eligible to join the Scheme. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_40">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:11.5pt;margin-left:0.5in;text-indent:-0.5in">40.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Mr Howell is a chief fire officer within the meaning of paragraph B1 FPSO, with more than 25 years of pensionable service. He w<span style="font-size:11.5pt">as appointed as a firefighter with Essex Fire and Rescue Service on 1 September 1988. He secured the rank of Chief Fire Officer with Suffolk Fire &amp; Rescue Service on 1 December 2004.  </span>Mr Howell commenced in employment with the Claimant as chief fire officer on 10 January 2009.  This was part way through the period of 25 years of pensionable service.  <span style="font-size:11.5pt">He reached 25 years of pensionable service on 1 September 2013. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_41">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-family:'Times New Roman';font-size:12pt;margin-left:0.5in;text-indent:-0.5in">41.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">According to an Opinion of Ms Felicity Cullen KC (at the time QC) dated 18 March 2010 (Ms Cullen’s Opinion) (and I find), Mr Howell’s contract of employment with the claimant (subject to the letter referred to below)<span style="font-family:'Times New Roman'">: “</span><span style="font-style:italic;font-family:'Times New Roman'">contains the following terms covering retirement and pension provision:</span></p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.39in"><span style="font-style:italic;font-family:Courier;font-size:9.5pt">"</span><span style="font-style:italic;font-family:'Times New Roman'">9. Retirement</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman'">Nominal Pension Age for members of the Firefighters' Pension Scheme is 55 with protection of certain benefits for those formerly with a compulsory retirement age of 60. For the New Firefighters' Pension Scheme the Normal Retirement Age is also 60. You are required to retire in accordance with the regulations of your pension scheme and no later than the day before your 65th birthday.</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-style:italic;font-family:'Times New Roman'">10.</num>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.5in"><span style="font-style:italic;font-family:'Times New Roman'">Pension Scheme</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman'">The Firefighters' Pension Scheme and the New Firefighters' Pension Scheme are administered on behalf of DSFRS by Devon Pensions Services. If you are a member of either of these pension schemes then you will be able to transfer your membership to the Service. The Firefighters' Pension Scheme and the New Firefighters' Pension Scheme are contracted out of the State Second Pension Scheme (S2P) which used to be called the State Earnings Related Pension Scheme. Further details on the scheme can be found on the DCLG website</span><span style="font-family:'Times New Roman'">.”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_42">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">42.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Doubts having arisen as to how the transitional provisions under the FA 2004 that I have outlined operated, the matter was submitted to Ms Cullen KC for her opinion.  The relevant background was described by her as follows:</p>
+	  </intro>
+	  <subparagraph>
+	    <num>“3.</num>
+	    <content>
+	      <p style="margin-left:0.79in;text-indent:0.32in"><span style="font-style:italic;font-family:'Times New Roman'">The CFO is concerned about the potential effect of changes in pensions tax legislation with effect from 6 April 2010 and has asked DSFRS to consider including within the Contract a clause permitting him to retire at age 50 in 2019.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-style:italic;font-family:'Times New Roman'">4.</num>
+	    <content>
+	      <p style="margin-left:0.79in;text-indent:0.21in"><span style="font-style:italic;font-family:'Times New Roman'">DSFRS is willing to consider this request but is concerned at the possibility of becoming subject to scheme sanction charges under the provisions of Part 4 FA 2004. I have been asked to advise on the potential liabilities to scheme sanction charges which may arise as a result of changes to the Contract. It has been specifically agreed that my advice will be limited to the relevant tax points and I am not required to consider the contractual and possible employment law issues raised in my letter of instruction.”</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_43">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">43.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The main part of her opinion is a discussion as to whether the rights under FPSO paragraph B1 are rights which are “actual or prospective” within the meaning of paragraph 22(4)(a), Schedule 36 FA 2004.  Her conclusion was as follows:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in;text-indent:0.11in">“<span style="font-style:italic;font-family:'Times New Roman'">In conclusion, it is my view that, on a proper construction of para.22 Schedule 36 FA 2004, the CFO is, in principle, entitled to benefit from a protected pension age of 50. The retirement condition (or any further requirements resulting from any changes in law) will have to be satisfied at the appropriate time if protection is to be available in fact. HMRC's Manuals indicate, however, that it may well take a different view to my own and this cannot, as a matter of practice be ignored.”</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_44">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">44.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The position of HMRC, as identified by Ms Cullen, reflects their position before me in this case. As she set out:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-style:italic;font-family:'Times New Roman'">“21.</num>
+	    <content>
+	      <p style="margin-left:0.79in;text-indent:0.32in"><span style="font-style:italic;font-family:'Times New Roman'">The key issue in relation to the condition in para.22(4)(a) Schedule 36 FA 2004 is whether a right which is, on its face, qualified in the sense that it is conditional on "permission" (the term used in Rule B1.(2) of the FPS), can be construed as being an actual or prospective right. HMRC thinks not: in its Manuals at RPSM 03106020, in describing the protected pension age requirements relating to rights to take benefits under age 55, it states that "the rights must be unqualified (in that no other party need consent to the individual's right before it becomes binding on the scheme or contract holder)." It is my view that a requirement for permission and a requirement for consent (the term used in RPSM 03106020) are indistinguishable for these purposes. Reference should also be made to RPSM 03106025.*</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman'">* In RPSM 03106025 HMRC states as follows:</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;font-family:'Times New Roman'">"Some rules give members an unqualified right to take benefits but only when certain conditions are met. If an individual meets the conditions providing the unqualified right to take benefits before age 55 they will have a protected pension age."</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman'">An example is then given relating to redundancy, but it may be possible to infer that a consent condition can become unqualified by the giving of consent or permission.”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_45">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">45.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In paragraph 17 of the Defence, HMRC’s position is stated shortly:</p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.39in">“<span style="font-style:italic;font-family:'Times New Roman'">17…..</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman';font-size:12pt;margin-left:1.28in;text-indent:-0.39in">(a)</num>
+	      <content>
+		<p class="ParaLevel5" style="margin-left:1.28in"><span style="font-style:italic;font-family:'Times New Roman'">It is admitted that paragraph 22 of FA 2004, Schedule 36, Part 3 requires an ‘actual or prospective right’;</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman';font-size:12pt;margin-left:1.28in;text-indent:-0.39in">(b)</num>
+	      <content>
+		<p class="ParaLevel5" style="margin-left:1.28in"><span style="font-style:italic;font-family:'Times New Roman'">However, as to paragraphs 3.11.1, 3.11.2 and 3.11.4, it is denied that the 1</span><span style="font-style:italic;vertical-align:super;font-size:smaller;font-family:'Times New Roman'">st</span><span style="font-style:italic;font-family:'Times New Roman'"> Defendant had, at the relevant time, an actual or prospective right: any entitlement to an early retirement pension was entirely dependent upon a 3rd party (the fire and rescue authority) giving, in the future, consent to early retirement (via the mechanism of an early retirement notice) – which consent might, or might not, be given;”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_46">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">46.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Before me, Ms Brown also referred to PTM062210 which goes on to explain what HMRC means by an unqualified right:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-family:Garamond;font-size:11.5pt">“</span><span style="font-family:'Times New Roman'">To have a protected pension age the member must have had the right to take benefits before normal minimum pension age. </span><span style="font-weight:bold;font-family:'Times New Roman'">That is not the ability to take benefits, but an unqualified right.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-weight:bold;font-family:'Times New Roman'">An individual has an unqualified right to take benefits if they do not need the consent of anybody before they can take their benefits. If the scheme documentation states that the consent of the trustees or employer is required to take benefits the member does not have an unqualified right to take benefits</span><span style="font-family:'Times New Roman'">.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-family:'Times New Roman'">(It does not matter that the trustees have always operated their discretion to allow the payment of early benefits, the right is still not an unqualified right.)</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-family:'Times New Roman'">For example, on 10 December 2003 a scheme may give its members an unqualified right to take pension benefits before age 55, but only if they are active members. Deferred members may take benefits before age 55 but only with the consent of the trustees or the employer. The active members as at 5 April 2006 who were also active members on 10 December 2003 or who joined the scheme after that date therefore have a protected pension age but the deferred members do not. On or after 6 April 2006, the employer decides that it will close its defined benefits section in the scheme and instead in future will provide benefits on a defined contributions basis in a new section of the existing scheme. As a result, those members who were active members of the defined benefits section on 5 April 2006 become deferred members of that section and active members of the defined contributions section (with a reserved right, qualified or unqualified) to take benefits before age 55. However, these members still retain their protected pension age as this is unaffected by any changes in scheme rules made from 6 April 2006 onwards. So, they are still able to take their benefits before age 55 after 2010 provided that consent to taking the deferred benefits (and their defined contribution section benefits if the right to them is qualified) is given and that they become entitled to all their scheme benefits under both the defined benefits and defined contributions sections on the same date</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-family:'Times New Roman'">(Emphasis added by Ms Brown).</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_47">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">47.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Following receipt of Ms Cullen’s opinion, by letter dated 31 March 2010, the Claimant proposed an amendment of Mr Howell’s contract of employment, which he accepted on or about 16 April 2010.  Having cited the provision regarding retirement that I have set out earlier, the claimant’s letter went on to say:</p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.78in">“<span style="font-style:italic;font-family:'Times New Roman'">In accordance with the Firefighters’ Pension Scheme 1992, the Devon &amp; Somerset Fire &amp; Rescue Authority have given permission for you to submit notice of your intention to retire from age 50 subject to the following:</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman'">1.</num>
+	      <content>
+		<p style="margin-left:1.18in;text-indent:0.32in"><span style="font-style:italic;font-family:'Times New Roman'">You being entitled at that time to reckon at least 25 years’ pensionable service; AND</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman'">2.</num>
+	      <content>
+		<p style="margin-left:1.18in;text-indent:0.32in"><span style="font-style:italic;font-family:'Times New Roman'">Subject to your not becoming entitled to an ill-health award under Rule B3 of the Scheme; AND</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman'">3.</num>
+	      <content>
+		<p style="margin-left:1.18in;text-indent:0.32in"><span style="font-style:italic;font-family:'Times New Roman'">Your notice of retirement not indicating that you intend to retire for the purpose of taking up employment with another fire and rescue service; AND</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <num style="font-style:italic;font-family:'Times New Roman'">4.</num>
+	      <content>
+		<p style="margin-left:1.18in;text-indent:0.32in"><span style="font-style:italic;font-family:'Times New Roman'">Any pensions benefit payable before the age of 55 not representing an unauthorised payment as defined in the Finance Act 2004</span><span style="font-family:Courier;font-size:11.5pt">.”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_48">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">48.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Two points can be made about this letter.  First, the permission to submit a notice of intention to retire from age 50 was dependent on any pensions benefit payable before the age of 55 not representing an unauthorised payment.  Secondly, if HMRC are correct on their construction of the relevant transitional provisions of schedule 36 FA 2004 as applied to the Scheme, this letter was too late to remove the need for any consent so as to make any right to an early pension (payable prior to the age of 55) not subject to consent or permission of any third party.  On HMRC’s case, the condition would have to have been met back on 5 April 2006.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_49">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">49.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The claimant is willing to make payments by way of pension to Mr Howell, prior to him reaching 55 but provided that such payments do not amount to unauthorised payments as defined by the provisions of the FA 2004 that I have set out earlier in this judgment.</p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid">The issues</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_50">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">50.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Unfortunately the parties were also unable to agree a formulation of the issues that the court was being asked to decide.</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-weight:bold;font-size:12pt;margin-left:0.89in;text-indent:-0.39in">(a)</num>
+	    <content>
+	      <p class="ParaLevel5" style="margin-left:0.89in"><span style="font-weight:bold">The key issue: paragraph 22(4)(a) sch 36 FA 2004: the entitlement condition: “actual or prospective right to benefits from an age of less than 55 as at 5 April 2006”</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_51">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">51.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The parties were agreed that the key issue was the application of the transitional provisions under Schedule 36 FA 2004 to the situation concerning Mr Howell and in particular the issue of whether or not within the meaning of paragraph 22 of Schedule 36 as at 5 April 2006 he had an “actual” or “prospective” right to benefits under the Scheme from an age of less than 55.  The precise formulation of any appropriate declaration remained in issue.  The issue as to formulation of the declaration was one that I considered should properly be considered after my judgment on the key issue.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_52">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">52.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I should add that a great deal of the written skeleton arguments was taken up with the issue of whether the court could or should make a declaration and if so on what jurisdictional basis. Some of this related to other relief apparently being sought by the Claimant, as I shall refer to later in this judgment.  As regards declaratory relief in relation to the “entitlement condition” Ms Brown submitted that such relief should be granted to her as a trustee seeking directions.  Mr Oakes submitted that Ms Brown’s client was not a trustee and therefore that any declaration could only be granted under the court’s general discretionary power and not in the context of its role in relation to trustees.  At the end of the day, Mr Oakes (and as I understood it, Ms Brown) accepted that, even under the general jurisdiction of the court, there was both jurisdiction and, as a matter of discretion, it would be appropriate for the court to make a declaration regarding the point of law arising with regard to whether or not, on the facts, Mr Howell fulfils the “entitlement condition” of paragraph 22 of schedule 36, FA 2014.  I need not therefore consider the question of the trustee status of the Claimant nor the general law relating to the grant of declaratory relief in that context any further.</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.5in">(b)<marker name="tab"/><span style="font-weight:bold">the “retirement condition” paragraph 22(7) Sch 36 FA 2004</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_53">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">53.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The second issue that surfaced during the hearing was whether or not the “retirement condition” was met.  As I have pointed out, whether the retirement condition is met appears largely to depend upon future events.  However, Ms Brown submitted that there were matters that were capable of being determined now. Her submission is that, first, all benefits payable under the Scheme will be payable at the same time, so that paragraph 22(7)(a) of schedule 36 FA 2004 is met. Secondly, she submits that paragraph 22(7)(b) does not apply in the circumstances here.  That is because, she says, paragraph 22(7)(b) does not apply at all unless on 5 April 2006 Mr Howell had an actual or prospective right under the Scheme to any benefit from an age of less than 50.  If he did then condition 1 has to be met and if it is not then conditions 2 or 3 have to be met.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_54">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">54.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Mr Oakes’ position was that HMRC had not come prepared to deal with this issue.   As regards 22(7)(a), HMRC needed more time to consider the Scheme as a whole and the benefits potentially payable under it which might go wider than simply a pension at age 50.  As regards paragraph 22(7)(b), he did not agree that as a matter of construction paragraph 7(b) was dealing solely with a situation where the member had, on 5 April 2006, an actual or prospective right to any benefit from an age of less than 50.  Rather, if that was the case then condition 1 had to be met.  If that was not the case (ie there was no such entitlement), then conditions 2 and condition 3 came into play and one at least had to be satisfied.  The words “in any other case” were a reference to any other case than where on 5 April 2006 the member had the relevant right, not a reference to a case where, in such circumstances, condition one was not met. I note that Ms Cullen KC’s opinion seems to proceed on the basis put forward by Mr Oakes.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_55">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">55.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown referred me to the particulars of claim and the defence. She said that the statements of case prevent HMRC from now raising a contrary case that the “retirement condition” is, or may, not be met.  True it is that the particulars of claim assert, for example in paragraphs 3.7 and 3.8, that the “only point of concern” was whether paragraph 22(4) of schedule 36 FA 2004 applies and that the Claimant’s position was that the  “other conditions” (that is of paragraph 22) are met. Further, the Defence simply “noted” these paragraphs.  Nevertheless I am not satisfied that the Second Defendant is prevented from raising the issue.  The hearing before me concentrated almost entirely upon the paragraph 22(4) point and the “entitlement” position. I heard very limited argument indeed on the retirement condition under paragraph 22(7), most of it directed to whether HMRC were prevented from denying the assertion that the condition was met.  The hearing as it was overran its time estimate by a substantial margin.  I do not consider that I should deal with the retirement condition issue without it being clearly formulated and relevant evidence and proper full submissions being made.  If it is necessary to allow HMRC to amend their statement of case I would allow them to do so but I do not consider that it is.  I would not be prepared to make any declaration in the particular circumstances based upon some form of pleading point that HMRC are not permitted to raise any counter arguments.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_56">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">56.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I will hear from counsel on hand down of this judgment whether these proceedings should be left alive to deal with the retirement condition on another day or whether the matter can be left to be dealt with (if it arises) in separate proceedings (subject to any <span style="font-style:italic">Henderson v Henderson</span> point).</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.5in">(c)<marker name="tab"/><span style="font-weight:bold">The trustee’s discretion: directions as to action to be taken</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_57">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">57.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As is clear to me from the statements of case and the draft list of issues, the key question before me was whether as a matter of law the “entitlement condition” was met (and more narrowly whether the first element of that condition was met).  However, in her skeleton argument for the hearing, Mr Brown commenced by saying that the Claimant had applied for an order that it is able to <span style="text-decoration-line:underline;text-decoration-style:solid">and should</span> make a payment to Mr Howell prior to his attaining the age of 55 (emphasis supplied).  In fact directions as to what the claimant “should” do (and in particular whether it should make a payment even if it did amount to an unauthorised payment) had never been raised before.  In her supplemental skeleton, Ms Brown suggested that the Claimant was seeking declaratory relief as to whether it would be within its powers to make a payment to Mr Howell before he attains the age of 55 without making provision for unauthorised payments.  This again seemed to be relief relating to the scope of the Claimant’s powers and how it should exercise them.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_58">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">58.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As I understood it Ms Brown ultimately accepted that she was not seeking the directions of or declarations by the court as to what the Claimant should do (which would involve consideration of a lot more evidence than that which was before me and might involve the need for joinder of other persons to the extent that for example, the making of an unauthorised payment might have an effect upon the relevant Scheme). The Claimant really needs to know what the legal position in relation to the entitlement condition in the case of Mr Howell and will then have to consider what course it is appropriate for it to take. Its current position, as I understand it, is that it is not prepared to make an early payment of pension (ie before Mr Howell attains the age of 55) if that would be an unauthorised payment under FA 2004.    I note however that, as I go on to explain later in this judgment, part of Ms Brown’s submissions seemed to be to the effect that the claimant had to make an early relevant payment in any event.</p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in;text-indent:-0.5in"><marker name="tab"/><span style="font-weight:bold">(d)  HMRC’s manual(s)</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_59">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">59.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">At one point it was, at the least, unclear whether it was being suggested that the court should grant some form of relief in relation to HMRC’s manual(s) which is/are said by the Claimant inaccurately to record the relevant law regarding the meaning and application of the “entitlement condition”.   It was clarified that no relevant relief is being sought in this respect and I need say no more about it.</p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold">Statutory construction and the meaning of legislation</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_60">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">60.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In my judgment, I have to construe the meaning of the words “actual or prospective right to benefits” in paragraph 22 of Schedule 36 to the FA 2014 and to decide whether or not Mr Howell’s position falls within that provision.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_61">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">61.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I was referred to a number of cases about statutory construction. I set out a summary of my main conclusions drawn from those authorities.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_62">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">62.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In conducting statutory interpretation, the courts are “<span style="font-style:italic">seeking the meaning of the words which Parliament used</span>” and identifying the meaning borne by the words in question in the particular context in which they are used.  The Court is not however to engage in a process of finding a meaning which is not justified by the words that Parliament has used, or which is selected for some reason other than the presumed intention of Parliament, such as the personal view of the judge  (<span style="font-style:italic">R(PRCBC) v Home Secretary</span> [2022] UKSC 3 at [29], [59], [66]; <span style="font-style:italic">Black-Clawson International Ltd v Papierwerke Waldhof-Aschffenburg AG</span> [1975] AC 591, 613 Per Lord Reid; <span style="font-style:italic">R v Secretary of State for the Environment Transport and the Regions, Ex P Spath Holme Ltd</span> [2001] AC 349, 396).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_63">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">63.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Statutory interpretation involves an objective assessment of the meaning which a reasonable legislature as a body would be seeking to convey using the statutory words which are being considered.  This means that, for example, the subjective intentions of the draftsman, the promoter, or individual members or even a majority of members are all irrelevant.  Parliament’s “intention” in this context is the intention reasonably imputed to Parliament in respect of the language used (<span style="font-style:italic">R(PRCBC) v Home Secretary</span> at [31], [59]; <span style="font-style:italic">Ex p Spath Holme Ltd</span> at 396-7).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_64">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">64.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">However, an expressed intention of a Government Minister may become relevant to ascertaining the objective intention of Parliament under the rule in <span style="font-style:italic">Pepper v Hart.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_65">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">65.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Part of the context will be the statutory context, that is the section of the relevant piece of legislation as a whole and the wider context of the relevant group of sections.  The statute as a whole may provide the relevant context.  They are the words Parliament has chosen to enact as an expression of the purpose of the legislation and are therefore the primary source by which meaning is ascertained (<span style="font-style:italic">R(PRCBC) v Home Secretary </span>at [29]).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_66">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">66.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Other external aids may cast light on the meaning of particular statutory provisions.  As regards statements made in Parliament, a special rule applies referred to in shorthand as the rule in <span style="font-style:italic">Pepper v Hart</span>, being named after the case in which the House of Lords relaxed the rule that there could be no reference to such material ([1993] AC 593).  I will deal with that rule separately.  What follows is dealing with external aids (that is aids external to the statute itself) other than matters covered by the rule in <span style="font-style:italic">Pepper v Hart</span>.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_67">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">67.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">External aids may cast light on the meaning of particular statutory provisions (for example Explanatory Notes to the legislation); disclose the background to a statute, the mischief it addresses and/or the purpose of the legislation thereby assisting in a purposive interpretation of a particular statutory provision (for example, Law Commission reports, Royal Commission reports, reports of advisory committees and Government White Papers ((<span style="font-style:italic">R(PRCBC) v Home Secretary</span> at [30]). </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_68">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">68.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Such external aids may also reveal that the language of a statute, initially thought to be clear, is in fact ambiguous. They may then assist the court in ascertaining the true meaning of the statute (<span style="font-style:italic">R(PRCBC) v Home Secretary</span> at [29], [63], [67], [76]; <span style="font-style:italic">Fothergill v Monarch Airlines Ltd</span> [1981] AC 251 at 281).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_69">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">69.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The court is also able to rely upon a body of principles of construction and/or prima facie assumptions or presumptions (<span style="font-style:italic">R(PRCBC) v Home Secretary</span> at [29], [41], [43] and see discussion of examples of these at [34]-[40]). </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_70">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">70.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The court will usually look at any external material drawn to its attention which properly throws light on the meaning of the words that Parliament has used.  That may include language dictionaries and/or legal dictionaries.  Further, other case law or other statute which uses similar language may be of assistance in understanding concepts or how meanings have been attributed to words in different contexts.  Indeed, at least some legal dictionaries (as will language dictionaries) give examples of the meaning attributed to words and concepts in different contexts. </p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-style:italic;font-weight:bold">Pepper v Hart</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_71">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">71.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">HMRC seek to support their contention as to the meaning of “actual and prospective” by referring to the statements made by a Government Minister, Ms Ruth Kelly MP, then Financial Secretary to the Treasury in Parliament during the passage of the then Finance Bill and which became FA 2004.  These comments were made by her during the consideration of the then Finance Bill by the Standing Committee of the House of Commons, which considered the amendment which became paragraph 22 of Schedule 36 FA 2004.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_72">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">72.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Such references are not a legitimate aid to statutory interpretation unless the three conditions set out by Lord Brown-Wilkinson in <span style="font-style:italic">Pepper v Hart</span> [1993] AC 593, 640 are met.  Those three conditions are: (1) that the legislative provision must be ambiguous, obscure or, on a conventional interpretation, lead to absurdity; (2) that the material must be or include one or more statements by a minister or other promoter of the Bill; and that (3) the statement must be clear and unequivocal on the point of interpretation which the court is considering, (see <span style="font-style:italic">R (Project for the Registration of Children as British Citizens) v Secretary of State for the Home Department</span> [2022] UKSC 3; [2022] 2 WLR 343, per Lord Hodge DPSC at paragraph [32]).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_73">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">73.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">There was a debate before me as to the meaning of “ambiguity” in this context.  Ms Brown submitted that “ambiguous” meant something more than “capable of bearing more than one meaning”.  In this respect she focussed upon the passage of the speech of Lord Browne-Wilkinson in <span style="font-style:italic">Pepper v Hart</span> as set out below (with her emphases):</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.78in"><span style="font-style:italic;font-family:'Times New Roman'">“Statute law consists of the words that Parliament has enacted. It is for the courts to construe those words and it is the court's duty in so doing to give effect to the intention of Parliament in using those words. It is an inescapable fact that, despite all the care taken in passing legislation, </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'">some statutory provisions when applied to the circumstances under consideration in any specific case are found to be ambiguous</span><span style="font-style:italic;font-family:'Times New Roman'">. One of the reasons for such ambiguity is that the </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'">members of the legislature in enacting the statutory provision may have been told what result those words are intended to achieve</span><span style="font-style:italic;font-family:'Times New Roman'">. Faced with a given set of words which are capable of conveying that meaning </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'">it is not surprising if the words are accepted as having that meaning. Parliament never intends to enact an ambiguity. Contrast with that the position of the courts. The courts are faced simply with a set of words which are in fact capable of bearing two meanings</span><span style="font-style:italic;font-family:'Times New Roman'">. The courts are ignorant of the underlying Parliamentary purpose. </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'">Unless something in "other parts of the legislation discloses such purpose, the courts are forced to adopt one of the two possible meanings using highly technical rules of construction</span><span style="font-style:italic;font-family:'Times New Roman'">. </span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'">In many, I suspect most, cases references to Parliamentary materials will not throw any light on the matter. But in a few cases it may emerge that the very question was considered by Parliament in passing the legislation. Why in such a case should the courts blind themselves to a clear indication of what Parliament intended in using those words? The court cannot attach a meaning to words which they cannot bear, but if the words are capable of bearing more than one meaning why should not Parliament's true intention be enforced rather than thwarted?”</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_74">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">74.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown’s submission was that nowhere does Lord Browne-Wilkinson “explain that ambiguous means capable of bearing more than one meaning”. I have difficulty with that proposition.  However, as I ultimately understood her submission, it was to the effect that if (without reference to the relevant Parliamentary statement sought to be adduced into evidence) relevant words used in a statute are words that the court considers to be capable of having more than one meaning (she would say “plausible meaning”) then the words will be “ambiguous” for the purposes of the rule in <span style="font-style:italic">Pepper v Hart.</span>  In this case, she says, the relevant words are not ambiguous.  If I am correct in my understanding then I do not consider Ms Brown’s submission to be contentious. </p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold">The “entitlement condition”</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_75">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">75.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown’s submission is that the meaning of “actual or prospective right” is not ambiguous.  She says that, as at 5 April 2006, Mr Howell had either an “actual” or a “prospective” right to benefits. She says that the meaning of “actual” and “prospective” is to be derived from dictionaries and are words of ordinary and wide meaning.  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_76">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">76.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As regards dictionary definitions, Ms Brown relied upon the meanings set out in the Merriam-Webster Dictionary online as follows:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-family:'Times New Roman';font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(1)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in"><span style="font-family:'Times New Roman'">As regards “actual”:</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.36in;text-indent:0.39in"><span style="font-weight:bold;font-family:'Times New Roman'">“1a: </span><span style="font-family:'Times New Roman'">existing in fact or reality</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman'">actual </span><span style="font-family:'Times New Roman'">events</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman'">actual </span><span style="font-family:'Times New Roman'">and imagined conditions</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.39in"><span style="font-weight:bold;font-family:'Times New Roman'">b: </span><span style="font-family:'Times New Roman'">not false or apparent</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:0.79in;text-indent:0.39in"><span style="font-style:italic;font-family:'Times New Roman'">actual </span><span style="font-family:'Times New Roman'">costs</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.39in;text-indent:0.39in"><span style="font-weight:bold;font-family:'Times New Roman'">c</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.39in;text-indent:0.39in"><span style="font-family:'Times New Roman'">—used for emphasis</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.39in;text-indent:0.39in"><span style="font-family:'Times New Roman'">This is the </span><span style="font-style:italic;font-family:'Times New Roman'">actual </span><span style="font-family:'Times New Roman'">room in which my grandfather was born.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.36in;text-indent:0.39in"><span style="font-weight:bold;font-family:'Times New Roman'">2: </span><span style="font-family:'Times New Roman'">existing or occurring at the time</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.36in;text-indent:0.39in"><span style="font-family:'Times New Roman'">caught in the </span><span style="font-style:italic;font-family:'Times New Roman'">actual </span><span style="font-family:'Times New Roman'">commission of a crime”</span></p>
+	    </intro>
+	    <subparagraph>
+	      <num style="font-family:'Times New Roman';font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(2)</num>
+	      <intro>
+		<p class="ListParagraph" style="margin-left:0.75in;text-indent:0.12in"><span style="font-family:'Times New Roman'">As regards “prospective”:</span></p>
+	      </intro>
+	      <subparagraph>
+		<content>
+		  <p class="ListParagraph" style="margin-left:0.75in"><span style="font-weight:bold;font-family:'Times New Roman'">1: </span><span style="font-family:'Times New Roman'">relating to or effective in the future</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="ListParagraph" style="margin-left:0.75in"><span style="font-weight:bold;font-family:'Times New Roman'">2a: </span><span style="font-family:'Times New Roman'">likely to come about</span><span style="font-weight:bold;font-family:'Times New Roman'">: EXPECTED</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="ListParagraph" style="margin-left:0.75in"><span style="font-family:'Times New Roman'">the </span><span style="font-style:italic;font-family:'Times New Roman'">prospective </span><span style="font-family:'Times New Roman'">benefits of this law</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="ListParagraph" style="margin-left:0.75in"><span style="font-weight:bold;font-family:'Times New Roman'">b: </span><span style="font-family:'Times New Roman'">likely to be or become</span></p>
+		</content>
+	      </subparagraph>
+	      <subparagraph>
+		<content>
+		  <p class="ListParagraph" style="margin-left:0.75in"><span style="font-family:'Times New Roman'">a </span><span style="font-style:italic;font-family:'Times New Roman'">prospective </span><span style="font-family:'Times New Roman'">mother</span></p>
+		</content>
+	      </subparagraph>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_77">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">77.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The submissions of Ms Brown to some extent developed over time.  As I understood it she formally retained her original submission set out in her first written skeleton argument that the rights of Mr Howell under the Scheme were either “actual” and/or “prospective” within the meaning of the entitlement condition.  That is on the basis, she submits, that they existed or existed at the relevant time (2006) and/or they were effective in the future.    Further, the rights could be both “real” (i.e. actual) and prospective.  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_78">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">78.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In oral submission, she made clear that she did not push the case that the rights were “actual” very strongly and that she primarily asserted that the rights were prospective.  That is because, although conditional, the rights to a pension were either “effective in the future” and/or “likely to come about”.  Further, she submitted that it was either not clear that the Claimant would be in a position to refuse permission to an early retirement notice or even that it had no choice in the matter and that therefore the entitlement to an early pension was “likely”, if not inevitable, to come about.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_79">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">79.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">She also submitted that on the true construction of the Scheme and rule B1, Mr Howell had an actual right to a pension prior to age 55 which was only defeasible by a condition subsequent (e.g. if permission of the Claimant to the retirement notice at the relevant time was not forthcoming).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_80">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">80.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Mr Oakes submitted that the relevant words of the entitlement condition required to be construed against the background of a consideration of:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(1)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in">the purpose of the legislation and the use of similar concepts in other relevant legislation. In particular, an “actual” right corresponds to an existing entitlement (usually denoting a pension in payment) and “prospective right” corresponds to an “accrued right” (denoting a current right to future payment but, in either event not a right which is conditional upon third party consent;</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(2)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in"> the explanatory notes to what was the Finance Bill 2004 (the “Explanatory Notes”);</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(3)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in">A statement to the relevant standing committee made by the then Financial Secretary to the Treasury, Ms Ruth Kelly MP.</p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_81">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">81.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The particular passage relied on as regards the Explanatory Notes is as follows:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="Default" style="margin-left:0.79in">“<span style="font-style:italic">Paragraphs 20-22 protect the rights of two groups to take a pension at an age below 55 after 2010. The first group, dealt with in paragraph 21, has rights to retire at ages between 50 and 55 conferred or created by their employer in the context of an employment relationship via the occupational pension scheme. This right must be capable of being exercised by the employee or ex-employee unilaterally save only for the </span><span style="font-style:italic;color:initial">happening of any relevant contingency. Thus a right subject to any qualification such as “subject to trustee consent” would not be protected</span><span style="font-style:italic;font-size:11.5pt;color:initial">.”</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_82">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">82.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Paragraph 21 of what was then schedule 34 of the Finance Bill 2004 contained slightly different wording to that which eventually emerged in the Finance Act 2004 schedule 36.  However, the general drift of the paragraph was entirely in line with the eventual form of paragraph 22 of Sch 36 FA 2004.  Further, the  “entitlement condition” in paragraph 21(2)(a) of the Bill mirrored that in paragraph 22 of schedule 36 FA 2014 in referring to the member having on 5 April 2006, an “<span style="font-style:italic">actual or prospective right under the pension scheme to a pension from an age of less than 55</span>”.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_83">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">83.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As regards the passage from Hansard, the context was the movement of government amendments nos. 521 to 524 to the Finance Bill 2004 during the course of the consideration of the Finance Bill 2004 by Standing Committee A on 22 June 2004.  Those amendments related to what became paragraph 22 of schedule 36 to the FA 2004.   Amendment 523 was as follows:</p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p style="margin-left:0.39in;text-indent:0.39in">“<span style="font-style:italic;color:#333333">schedule 34, page 475, leave out lines 1 to 8 and insert</span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;color:#333333">'(a) on 5th April 2006 the member had an actual or prospective right under the pension scheme to a pension from an age of less than 55,</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;color:#333333">(b) the rules of the pension scheme on 10th December 2003 included provision conferring such a right on some or all of the persons who were then members of the pension scheme, and</span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p style="margin-left:1.18in"><span style="font-style:italic;color:#333333">(c) such a right either was then conferred on the member or would have been had the member been a member of the scheme on that date.'.[Ruth Kelly.]”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_84">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">84.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Amendment 523 was duly made in due course.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_85">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">85.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">The provision that amendment 523 replaced in the Bill was the definition of the “entitlement condition”.  Schedule 34, page 456 of the Bill at the bottom of the page started with the then draft entitlement condition which was: “22(2). The entitlement condition is-”.  Lines 1 to 8 as replaced on page 475 of the Bill was to the following effect:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.79in"><span style="font-style:italic">(a) in the case of a relevant statutory scheme as defined in section 611A of ICTA or a pension scheme treated by the Inland Revenue as if it were such a relevant statutory scheme, on 5th April 2006 the member had an actual or prospective right under the pension scheme to a pension from an age of less than 55, or </span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.79in"><span style="font-style:italic">(b) in any other case, the member had such a right under the pension scheme throughout the period beginning with 10th December 2003 and ending with 5th April 2006</span>.”</p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_86">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">86.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Speaking to the various amendments, the Financial Secretary to the Treasury said the following:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in">“<span style="font-style:italic;font-weight:bold;font-family:'Times New Roman';color:#333333">Ruth Kelly: </span><span style="font-style:italic;font-family:'Times New Roman';color:#333333">Pensions receive favourable tax treatment to encourage people to save for retirement. The deal between the Government and the pension saver is that that favourable tax treatment is conditional on using most of the savings built up in that way to generate retirement income, and not for other purposes. As part of the reform of tax rules for pensions, we intend to set the minimum age at which tax-privileged pensions can be drawn at 55 from 2010. That minimum benefit age will apply to all pensions that qualify for tax relief. Moving the minimum benefit age to 55 is not designed to prevent people from stopping work when they are younger than 55, if they can afford to do so using resources other than pensions, but they will not be able to use pensions built up with tax relief until the age of 55.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman';color:#333333">It would, of course, be unfair to introduce such a change in a way that cut across people's contractual rights to take an occupational pension at an earlier age. People with such rights may well have planned for their future on that basis, or even taken redundancy from their employer in the expectation that their occupational pension would become payable before they reached the age of 55. Because of that, provisions in the schedule protect the rights of employees in occupational pension schemes to retire before 55, provided certain conditions are met: first, that the right was in place before 10 December 2003 and, secondly, that the right is an absolute right and not subject to any conditions such as the consent of the employer.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman';color:#333333">Amendments Nos. 520 to 522 are tidying-up amendments that correct and clarify references to minimum pension age. Following representations on theDecember 2003 consultation document, we are now proposing a relaxation of the original proposals.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman';color:#333333">Amendments Nos. 523 and 524 would extend the protection to individuals who join their occupational pension scheme after 10 December 2003 but before 6 April 2006 A-day. They will be able to retire at the scheme's minimum pension age or normal retirement age provided that on 10 December 2003 the occupational pension scheme offered such a date to all existing members.”</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_87">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">87.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As regards the rights that Mr Howell had under the Scheme as at April 2006, Mr Oakes submits that Mr Howell did not then have an actual or prospective  right to a pension.  The right would only come into being once permission of the Claimant was given.  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_88">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">88.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown made a number of points regarding the reliance of Mr Oakes on other statutory provisions and their interpretation by the courts, the reliance on the Explanatory Notes and the reliance on Hansard.  I do not set them all out here but they included (at various stages) that there was no need to construe the relevant provisions of the FA 2004 which was clear and unambiguous, there was therefore no need to look at the Explanatory Notes and no ability to look at  Hansard and the relevant statement of Ms Kelly MP, the statements in the Explanatory Notes and of Ms Kelly MP were themselves unclear and required to be construed and could not be relied upon in the exercise that I had to undertake and that other statutory provisions used other language and concepts and were therefore either not to be looked at or, having been looked at, provided no assistance.  Finally, the provisions of rule B1 of Schedule 2 FPOS, did not fall within the description given by the Explanatory Notes or Ms Kelly MP as to the matters excluded from “actual or prospective rights”.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_89">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">89.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">First of all, it seems to me that Ms Brown is wrong to say that the meaning of the relevant constituent elements of the entitlement condition can be determined simply by looking at a dictionary of the English language.  I will come onto the meaning of “actual” separately but, leaving that aside, the “likelihood” of something happening, for the prospective test, is an uncertain test. One of the dictionary examples is a “prospective mother” but one can see that in some contexts that might be limited to a pregnant female whereas in others it might extend to a female who is hoping and planning to become pregnant.  Clearly as at 2006 a firefighter who was, say 38 years old, might be said have a prospective right to a pension at some age, even that were contingent on the firefighter achieving the relevant pensionable age under the relevant scheme.  Further, as well as what might be said to be naturally occurring contingencies, that right might be conditional on the firefighter not then taking up certain sorts of employment. Such a condition would be within the firefighters’ control.  However, the more the contingencies depend not on actions of the firefighter or the occurrence of natural events, the more questionable it becomes as to whether the right is a “prospective” right.  Further, if the test is “likelihood” does the answer depend on the factual position in relation to the individual concerned?  If they are diagnosed with a condition in 2006 that at the time is likely to lead to death shortly and is incurable, but the firefighter in fact survives, would he not have had a prospective right as at 2006 on the basis that as regards him it was then very unlikely that he would survive to pension age?</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_90">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">90.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Further, it is clear that in other areas of the law, “prospective” may be contrasted with “contingent” (see e.g. debts under the Insolvency Act 1986 and <span style="font-style:italic">Stonegate Securities Ltd v Gregory </span>[1980] 1 Ch 576 at 579E-F).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_91">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">91.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In short, it seems to me that the meaning of “actual or prospective right to benefits” is not one that can be answered solely by looking at a dictionary definition.  In any event, as I go on to consider, the Explanatory Notes can, in my judgment, be relied upon to identify that there is indeed an ambiguity in the terms in question.   I do not consider that the words are not capable of bearing the meaning that the Explanatory Notes give, that is one which excludes a right which is contingent on some third-party consent.  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_92">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">92.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown submitted that the court should first consider the meaning of the words and that if they are clear there is “no need to delve into the policy background”.  However, that is to ignore the point that the courts have said that Explanatory Notes or background information may in fact identify an ambiguity in the language.  Even if I am incorrect that the language is ambiguous, then the Explanatory Notes in this case fulfil exactly that function.  I also reject Ms Brown’s submission that Explanatory Notes should not be taken into account, alternatively given no weight, on the basis that they are “technical, difficult to find and difficult to understand” and are not therefore “readily available”.  Indeed, I also note that, as Mr Oakes pointed out, the Explanatory Notes were themselves expressly considered by Parliament at various stages of the passage of the Bill (although not the provisions I am dealing with).  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_93">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">93.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I turn to the authorities relied upon by Mr Oakes as, he submits, throwing light upon the transitional provisions in this case and the meaning to be given to “actual or prospective rights” as part of the entitlement condition.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_94">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">94.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Turning first to “actual right”, Mr Oakes submits that this means a right which existed as at 5 April 2006 in an unqualified form at that time in the sense that at that time there was an unqualified right to receive benefits (i.e. in this case the pension).  He submits that as at 5 April 2006 Mr Howell had no immediate unqualified right to a pension: his right to a pension under the Scheme was a right to a pension in the future if and when (among other things) he attained the relevant age. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_95">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">95.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I accept Mr Oakes’ submissions to the effect that an “actual right” to a benefit in this context is to be equated with the concept of unconditional “entitlement to payment” rather than having any element of prospectivity about it.  This is supported, by example, by the Explanatory Notes to what was clause 205 of the Finance Bill 2004 and which is now section 216 of the FA 2004.  Section 216 identifies benefit crystallisation events and the amount crystallised in the context of the lifetime allowance charge.  It draws a distinction between persons becoming entitled to certain benefits (eg a pension or an annuity) and the individual reaching a certain age when “prospectively entitled” to various benefits.  The Explanatory Notes to clause 205 of the Finance Bill 2004 (which became s216 FA 2004) explain:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.79in">“<span style="font-style:italic;font-size:11.5pt">‘The point at which an individual becomes entitled to the payment of a pension is when the right to receive it becomes actual as opposed to prospective, or in other words, when the pension payments commence”.</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_96">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">96.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in"><span style="font-size:11.5pt">Furthermore, previous pensions legislation has sought to protect rights already granted.  Section 67(2) of the Pensions Act 1995, in its original form, prevented exercise of any power conferred on a person to modify an occupational pension scheme:</span></p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.98in;text-indent:-0.2in"><span style="font-size:11.5pt">“  </span><span style="font-style:italic;font-size:11.5pt">on any occasion in a manner which would or might affect any entitlement, or accrued right, of any member of the scheme acquired before the power is exercised </span><span style="font-size:11.5pt">[…]” </span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_97">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">97.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Section 67(2) as amended makes voidable the exercise of a power in relation to “subsisting rights” defined as being:</p>
+	  </intro>
+	  <subparagraph>
+	    <intro>
+	      <p class="Default" style="margin-left:0.11in;text-indent:0.39in"><span style="font-style:italic">(a) in relation to a member of an occupational pension scheme, at any time– </span></p>
+	    </intro>
+	    <subparagraph>
+	      <content>
+		<p class="Default" style="margin-left:0.79in"><span style="font-style:italic">(</span><span style="font-style:italic;font-family:'Times New Roman'">i) any right which at that time has accrued to or in respect of him to future benefits under the scheme rules, or </span></p>
+	      </content>
+	    </subparagraph>
+	    <subparagraph>
+	      <content>
+		<p class="ParaLevel1" style="margin-left:0.79in"><span style="font-style:italic;font-family:'Times New Roman'">(ii) any entitlement to the present payment of a pension or other benefit which he has at that time, under the scheme rules, </span><span style="font-family:'Times New Roman'">[…]”</span></p>
+	      </content>
+	    </subparagraph>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_98">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">98.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">This suggests, at the least, the possibility of a distinction in the entitlement condition between an “actual right” (being equivalent to an entitlement) and an prospective right (being equivalent to an “accrued right”).  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_99">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">99.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I was referred to a number of cases construing relevant pension legislation.  They included <span style="font-style:italic">Courage Groups Pension Schemes </span>[1987] 1 All ER 528; <span style="font-style:italic">AON Trust Corporation v KPMG</span> [2005] EWCA Civ 1004; <span style="font-style:italic">Danks v Qinetiq</span> [2012] EWHC 570; <span style="font-style:italic">Barclays Bank v Holmes</span> [2000] BPIR 339; <span style="font-style:italic">Briggs v Gleeds</span> [2014] EWHC 1178 (Ch) and <span style="font-style:italic">Entrust Pension v Prospect</span> [2012] EWCH 1666 (Ch). It is notable in the latter case that a “right” to a definable share of surplus was purely discretionary and that this was not therefore a right or entitlement within the relevant meaning of the instrument in question.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_100">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">100.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I also note that in <span style="font-style:italic">Alexander Forbes Trustee Services Limited v Clarke </span>[2008] EWHC 153 (Ch), the meaning of “<span style="font-style:italic">where a person’s entitlement to payment of a pension or other benefit has arisen</span>” was in question.  In that context, “entitlement” was found to be capable of extending beyond a pension already in payment to a situation where all the requirements for receipt of pension benefits had already been fulfilled or “lay wholly in the hands” of the relevant member.  This appears to be an example where “entitlement" in the particular context went beyond its more narrow meaning where used in contradistinction to “accrued right”.  Again, it demonstrates that resort to dictionaries does not yield the entire answer.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_101">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">101.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Not by way of reliance on the meaning of the words given by her, but by way of illustrating that the relevant words of the entitlement condition in paragraph 22 of Schedule 36 FA 2004 are capable of bearing the meaning attributed to them by Mr Oakes (at least as regards the meaning of “actual right” contrasted with “prospective right”),   I note also that Ms Ruth Kelly MP, in the context of became section 216 (the crystallisation clause) in answer to a number of comments by Mr George Osborne MP confirmed that:</p>
+	  </intro>
+	  <subparagraph>
+	    <content>
+	      <p class="Default" style="margin-left:0.79in">“<span style="font-style:italic">the hon. Gentlemen seem to have misunderstood the Bill. The concept of entitlement is clearly defined. It is consistent and it recurs throughout the tax simplification legislation. A benefit crystallisation event is triggered on the individual becoming entitled to a certain benefit. Entitlement has a clear meaning in the legislation, as set out in clause 155. The legislation uses “entitled” to mean the point at which an individual’s right to receive benefits under a pension scheme cease to be prospective and become actual</span>”: <span style="font-style:italic">Hansard </span>15 June 2004, Column 578, Clause 205.</p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_102">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">102.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown submits that I am not entitled to consider or, if I am, that I gain no assistance from, the case law on different statutory provisions and which use different terminology. I disagree.  The concepts are useful and analogous and they demonstrate that the relevant words of the entitlement condition are capable of bearing the meaning given by Mr Oakes.   </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_103">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">103.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In my judgment, whatever rights Mr Howell had in 2006 to receive benefits under the Scheme, those rights were not, as at 5 April 2006, “actual” within the meaning of paragraph 22 schedule 36 FA 2004.  The real issue is whether they were “prospective rights” and therefore whether or not they do not qualify as such because of the contingency that they depend upon the consent of the claimant being given to the retirement notice as required by rule B1 of the Scheme.  Furthermore, the words “prospective right” in the definition of the entitlement condition, are words that, in my judgment, are capable as a matter of language of excluding any entitlement that will only arise if and when a third party exercises a discretion or gives some consent or permission.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_104">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">104.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In those circumstances, the Explanatory Notes are, in my judgment, clear that the words “actual or prospective” right to benefits excludes the situation where the right will only arise if a third party exercises a discretion or gives consent or permission. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_105">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">105.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I should also note that, even if I am wrong about the boundary line between “actual and “prospective” rights, the Explanatory Notes make clear that the circumstances where a third party has to give consent/permission before the right arises is one outside the entitlement condition set out in paragraph 22(2)(a) of Schedule 36 FA 2004.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_106">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">106.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in"> As regards the Explanatory Notes, Ms Brown submits that the notes only refer to “trustee consent” whereas here the issue is employer consent or permission.  I am not sure that that is correct. It seems to me that the consent required under FPSO is in fact that of the Claimant as relevant manager of the Scheme. In any event, the Explanatory Note is clear that the key is whether the right can be exercised unilaterally by the employee and of course that is not the case under FPSO (though I revert to that issue later in this judgment).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_107">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">107.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I also reject the submission that it is necessary to construe the Explanatory Note and that it is difficult in its meaning or unclear. In my judgment the Explanatory Note is perfectly clear and makes sense in the overall policy context of the FA 2004’s relevant transitional provision.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_108">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">108.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I turn to consider the question of the admissibility and effect of the statement of Ms Ruth Kelly MP to Standing Committee A on the relevant amendment (which was accepted and which became the entitlement condition) as set out in the Hansard extract that I have quoted.  It seems to me that that statement in real terms replicates the relevant note in the Explanatory Notes.  As such it may add little and it is probably not admissible on the basis that without it the meaning of the relevant entitlement condition is clear, using the Explanatory Notes, without having to resort to Hansard.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_109">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">109.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Of the statement by Ms Kelly MP, Ms Brown says that the legislation is not ambiguous because resort to the English dictionary shows that it is not ambiguous.  I do not agree. I do agree however that the relevant statutory provision is not ambiguous once it is construed against the background of the Explanatory Note.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_110">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">110.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Strictly therefore I do not consider that the Hansard extract is admissible because I do not consider that there is ambiguity.  If I am wrong on that point, I consider that the other pre-conditions of <span style="font-style:italic">Pepper v Hart</span> are met. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_111">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">111.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I should note that at one point Ms Brown submitted that the relevant ministerial statement was not admissible because it was made only to a standing committee and not the whole House but of course that was the case in <span style="font-style:italic">Pepper v Hart</span> itself. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_112">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">112.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown also submitted that the Hansard extract does not expressly discuss the provision in question or the transitional scheme at all. I disagree.  </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_113">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">113.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in"> Ms Brown also submitted that the passages relied upon represent the intention of the Minister not the intention of Parliament. I disagree. Inevitably a relevant ministerial statement will express the intention of the Minister (or the Government) as to what words in a Bill are to mean if enacted but if that intention is expressly set out to Parliament and Parliament accepts the relevant wording then the intention of the Minister/Government is adopted by and becomes the intention of Parliament.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_114">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">114.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown also submitted that the statement of Ruth Kelly MP was unclear and contradictory because it cuts across her (Ms Kelly’s) earlier statement that it would be unfair to introduce a change which cuts across people’s rights to take a pension at an earlier age. I disagree with both propositions. In my judgment the statement is clear.  Further it does not contradict her earlier statement, rather it explains what amount to rights that cannot be cut across and other “rights” which can be. </p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_115">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">115.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Accordingly, my conclusions are:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.64in;text-indent:-0.25in">(1)</num>
+	    <content>
+	      <p class="ParaLevel2" style="margin-left:0.64in;text-indent:0.12in">to be an “actual right to a benefit” within the meaning of paragraph 22 of Schedule 36 FA 2004, the right must be an immediate right to the benefit and subject to no contingencies;</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.64in;text-indent:-0.25in">(2)</num>
+	    <content>
+	      <p class="ParaLevel2" style="margin-left:0.64in;text-indent:0.12in">that where there is no immediate right to a benefit but a contingent future right subject to future contingencies, the right will be a prospective right (subject to (iii));</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.64in;text-indent:-0.25in">(3)</num>
+	    <content>
+	      <p class="ParaLevel2" style="margin-left:0.64in;text-indent:0.12in">future contingences, such as the occurrence of natural events (attaining a certain age) or contingencies wholly within the control of the member (such as not taking certain specified types of employment on retirement (as in rule B1(2)(a)) or not making an election under the Scheme rules, as in B1(2)(c)) are contingencies that are consistent with the right being prospective.  However, a condition that requires consent or permission of a third party before there is any right to a pension will be a contingency that will result in there not being a “prospective right to a benefit” within the meaning of FA 2004, schedule 36 paragraph 22.</p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold">FPSO and how FA 2014 applies to it</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_116">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">116.</num>
+	  <intro>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In my judgment:</p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(1)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in">Rule B1(3) FPSO confers an entitlement, on retirement, to an ordinary pension calculated in accordance with Part 1 of Schedule 2 on a person “to whom this rule applies”;</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-size:12pt;margin-left:0.75in;text-indent:-0.25in">(2)</num>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.75in;text-indent:0.12in">The rule does not apply to a Chief Fire Officer, if he retires before the age of 55, <span style="text-decoration-line:underline;text-decoration-style:solid">unless</span> his notice of retirement was given with the permission of (in this case, the Claimant);</p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <content>
+	      <p class="ParaLevel1" style="margin-left:0.5in">There is therefore, at most, an entitlement conditional upon permission of a third party. I deal further below with Ms Brown’s submissions as to the nature of the “permission” in question and its effect. </p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<paragraph eId="para_117">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">117.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Further, I accept Mr Oakes’ submission that the natural reading of the rule is that there is no right in a CFO to receive an early pension unless and until permission to give notice of (early) retirement is given.  There is no right before such permission and this is not a case where the right is subject to a condition subsequent which will remove an existing right.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_118">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">118.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">I return to the question of permission and consent and how that fits in with the meaning of the 2004 FA with regard to the first element of the entitlement condition.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_119">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">119.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As I have said, I do not consider that there is anything in the point that the Explanatory Notes give an example of a third party consent (a trustee) and not that of an employer.  Further, if there is said to be an ambiguity then the Ruth Kelly MP statement should be allowed in and that does cover employers too.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_120">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">120.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown’s submission is that, even if necessary consent of a third party to the grant of a pension right is outside the protection of the transitional provisions, because it does not meet the meaning of an “actual or prospective” right to a benefit, the requirement of permission within rule B1 of FPSO does not fall foul of this principle.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_121">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">121.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">First,  she submits that “permission” is different to “consent” and that in this case “permission” does not operate as a “consent”. She also submits that rule B1 does not have words such as “subject to trustee consent”.  I do not accept these submissions. Whether called “permission” or “consent”, in effect the Claimant has to take the further step of agreeing that a retirement notice can be given if the right to an early pension is to be activated.  Mr Howell did not as at April 2006 have a right to an early pension dependent only upon his own actions or the happening of natural contingencies (such as attaining the relevant age). He was then dependent on receiving permission (or consent) of the Claimant in the future.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_122">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">122.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Secondly, she submits that the Claimant, whether as manager of the scheme (or, she would say, trustee) or as employer would not in practice be able to refuse permission, the only right to refuse permission being confined to matters of “timing and form”.  As regards inability to refuse consent she submitted that the employer could not realistically refuse permission to give notice of retirement because the contract of service would not be enforceable because specific performance would not be granted (citing cases such as <span style="font-style:italic">Lumley v Wagner</span> (1843-60) ALL ER Rep 368; <span style="font-style:italic">C H Giles &amp; Co. Ltd v Norris</span> [1972] 1 ALL ER 960 and <span style="font-style:italic">Warner Bros v Nelson</span> [1937] 1 KB 209).</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_123">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">123.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">As regards the latter point this seems to me to confuse ability to refuse consent to retirement and ability to refuse consent (or permission) to give notice of early retirement which triggers the right to an early pension. I was unclear on what basis Ms Brown said that the right to refuse permission was confined to timing or form and indeed what that meant.  She suggested that a notice might be refused where the services of the chief fire officer were required to enable time to arrange a successor but accepted that if refused that could prevent any right to an early pension.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_124">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">124.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Ms Brown also suggested that there was no ability to refuse permission under rule B1 FPSO because this would amount to a refusal to allow an early pension and amount to constructive dismissal.    I accept Mr Oakes’ submission that this submission was not made out on the facts.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_125">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">125.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">Accordingly, I consider that as at 5 April 2006, Mr Howell did not have an actual or prospective right to benefits under the Scheme, in terms of a right to an early pension, within the meaning of the entitlement condition set out in paragraph 22 of schedule 36 FA 2004.  This is because although he was within the Scheme, any right he had was contingent upon and did not arise unless and until the Claimant gave its permission for him to serve a relevant (early) notice of retirement for the purposes of the Scheme. The need for such third party consent means that he did not satisfy the entitlement condition as properly construed.</p>
+	  </content>
+	</paragraph>
+	<level>
+	  <content>
+	    <p class="ParaLevel1"><span style="font-weight:bold">Conclusion</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_126">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">126.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In my judgment, such contingent right as Mr Howell had, as at 5 April 2006, under rule B1 of the FPSO to an early pension, that is one to be received under the age of 55, was not an “actual” or “prospective” right to benefits under paragraph 22 of Schedule 36 FA 2004.  Accordingly, the entitlement condition laid out in that paragraph was not met. It follows that any payment to him of a pension under the Scheme under FPSO prior to him reaching the age of 55 will amount to an unauthorised payment under FA 2004.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_127">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">127.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">A draft minute of order having been lodged (which sets out what is agreed, and identifying the non-agreed respective proposals of the parties where there is non-agreement), short skeleton arguments regarding consequential matters should be filed and served by 4pm on Monday 13 February 2023.  A remote hearing will be arranged by the court, if necessary at any time after 9:30am hopefully in that week and the parties should approach the court to make appropriate arrangements by 10am Tuesday 14 February 2023.</p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_128">
+	  <num style="font-style:normal;font-weight:normal;text-decoration-line:none;font-size:12pt;margin-left:0.5in;text-indent:-0.5in">128.</num>
+	  <content>
+	    <p class="ParaLevel1" style="margin-left:0.5in">In the meantime, I also make an order adjourning all consequential matters (including permission to appeal) and extend the time for filing a notice of appeal so that the 21 day period runs from the date that the final order is sealed.</p>
+	  </content>
+	</paragraph>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/tests/fixtures/ewhc-ch-2023-257_replacements.txt
+++ b/src/tests/fixtures/ewhc-ch-2023-257_replacements.txt
@@ -1,0 +1,72 @@
+{"case": ["[2022] UKSC 3", "[2022] UKSC 3", "2022", "https://caselaw.nationalarchives.gov.uk/uksc/2022/3", true]}
+{"case": ["[1975] AC 591", "[1975] AC 591", "1975", "#", false]}
+{"case": ["[2001] AC 349", "[2001] AC 349", "2001", "#", false]}
+{"case": ["[1993] AC 593", "[1993] AC 593", "1993", "#", false]}
+{"case": ["[1981] AC 251", "[1981] AC 251", "1981", "#", false]}
+{"case": ["[1993] AC 593", "[1993] AC 593", "1993", "#", false]}
+{"case": ["[2022] UKSC 3", "[2022] UKSC 3", "2022", "https://caselaw.nationalarchives.gov.uk/uksc/2022/3", true]}
+{"case": ["[2022] 2 WLR 343", "[2022] 2 WLR 343", "2022", "#", false]}
+{"case": ["[1980] 1 Ch 576", "[1980] 1 Ch 576", "1980", "#", false]}
+{"case": ["[1987] 1 All ER 528", "[1987] 1 All ER 528", "1987", "#", false]}
+{"case": ["[2005] EWCA Civ 1004", "[2005] EWCA Civ 1004", "2005", "https://caselaw.nationalarchives.gov.uk/ewca/civ/2005/1004", true]}
+{"case": ["[2014] EWHC 1178 (Ch)", "[2014] EWHC 1178 (Ch)", "2014", "https://caselaw.nationalarchives.gov.uk/ewhc/ch/2014/1178", true]}
+{"case": ["[2008] EWHC 153 (Ch)", "[2008] EWHC 153 (Ch)", "2008", "https://caselaw.nationalarchives.gov.uk/ewhc/ch/2008/153", true]}
+{"case": ["[1937] 1 KB 209", "[1937] 1 KB 209", "1937", "#", false]}
+{"leg": ["Coronavirus Act 2020", "http://www.legislation.gov.uk/id/ukpga/2020/7", "2020 c. 7"]}
+{"leg": ["Corporation Tax Act 2010", "http://www.legislation.gov.uk/id/ukpga/2010/4", "2010 c. 4"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["FA 2014", "http://www.legislation.gov.uk/id/ukpga/2014/26", "2014 c. 26"]}
+{"leg": ["FA 2014", "http://www.legislation.gov.uk/id/ukpga/2014/26", "2014 c. 26"]}
+{"leg": ["FA 2014", "http://www.legislation.gov.uk/id/ukpga/2014/26", "2014 c. 26"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Finance Act 2004", "http://www.legislation.gov.uk/id/ukpga/2004/12", "2004 c. 12"]}
+{"leg": ["Insolvency Act 1986", "http://www.legislation.gov.uk/id/ukpga/1986/45", "1986 c. 45"]}
+{"leg": ["Reserve Forces Act 1980", "http://www.legislation.gov.uk/id/ukpga/1980/9", "1980 c. 9"]}
+{"leg": ["Reserve Forces Act 1996", "http://www.legislation.gov.uk/id/ukpga/1996/14", "1996 c. 14"]}
+{"leg": ["Social Security Act 1975", "http://www.legislation.gov.uk/id/ukpga/1975/14", "1975 c. 14"]}

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -1,6 +1,30 @@
+from pathlib import Path
+
 import pytest
 
-from replacer.make_replacments import split_text_by_closing_header_tag
+from replacer.make_replacments import (
+    make_post_header_replacements,
+    split_text_by_closing_header_tag,
+)
+
+FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
+
+
+class TestMakePostHeaderReplacements:
+    original_file_content = open(
+        f"{FIXTURE_DIR}/ewhc-ch-2023-257_original.xml", "r", encoding="utf-8"
+    ).read()
+    replacement_content = open(
+        f"{FIXTURE_DIR}/ewhc-ch-2023-257_replacements.txt", "r", encoding="utf-8"
+    ).read()
+    expected_file_content = open(
+        f"{FIXTURE_DIR}/ewhc-ch-2023-257_enriched_stage_1.xml", "r", encoding="utf-8"
+    ).read()
+
+    content_with_replacements = make_post_header_replacements(
+        original_file_content, replacement_content
+    )
+    assert content_with_replacements == expected_file_content.strip()
 
 
 class TestSplitTextByClosingHeaderTag:

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -11,20 +11,23 @@ FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
 
 
 class TestMakePostHeaderReplacements:
-    original_file_content = open(
-        f"{FIXTURE_DIR}/ewhc-ch-2023-257_original.xml", "r", encoding="utf-8"
-    ).read()
-    replacement_content = open(
-        f"{FIXTURE_DIR}/ewhc-ch-2023-257_replacements.txt", "r", encoding="utf-8"
-    ).read()
-    expected_file_content = open(
-        f"{FIXTURE_DIR}/ewhc-ch-2023-257_enriched_stage_1.xml", "r", encoding="utf-8"
-    ).read()
+    def test_make_post_header_replacements(self):
+        original_file_content = open(
+            f"{FIXTURE_DIR}/ewhc-ch-2023-257_original.xml", "r", encoding="utf-8"
+        ).read()
+        replacement_content = open(
+            f"{FIXTURE_DIR}/ewhc-ch-2023-257_replacements.txt", "r", encoding="utf-8"
+        ).read()
+        expected_file_content = open(
+            f"{FIXTURE_DIR}/ewhc-ch-2023-257_enriched_stage_1.xml",
+            "r",
+            encoding="utf-8",
+        ).read()
 
-    content_with_replacements = make_post_header_replacements(
-        original_file_content, replacement_content
-    )
-    assert content_with_replacements == expected_file_content.strip()
+        content_with_replacements = make_post_header_replacements(
+            original_file_content, replacement_content
+        )
+        assert content_with_replacements == expected_file_content.strip()
 
 
 class TestSplitTextByClosingHeaderTag:

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -16,4 +16,4 @@ class TestSplitTextByClosingHeaderTag:
     @pytest.mark.parametrize("invalid_closing_header_tag", ["</foo>", "<foo/>"])
     def test_no_split(self, invalid_closing_header_tag):
         file_content = f"ABC{invalid_closing_header_tag}DEF"
-        assert split_text_by_closing_header_tag(file_content) == [file_content]
+        assert split_text_by_closing_header_tag(file_content) == ["", "", file_content]

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -34,13 +34,13 @@ class TestSplitTextByClosingHeaderTag:
     @pytest.mark.parametrize("closing_header_tag", ["</header>", "<header/>"])
     def test_split_text_by_closing_header_tag(self, closing_header_tag):
         file_content = f"ABC{closing_header_tag}DEF"
-        assert split_text_by_closing_header_tag(file_content) == [
+        assert split_text_by_closing_header_tag(file_content) == (
             "ABC",
             closing_header_tag,
             "DEF",
-        ]
+        )
 
     @pytest.mark.parametrize("invalid_closing_header_tag", ["</foo>", "<foo/>"])
     def test_no_split(self, invalid_closing_header_tag):
         file_content = f"ABC{invalid_closing_header_tag}DEF"
-        assert split_text_by_closing_header_tag(file_content) == ["", "", file_content]
+        assert split_text_by_closing_header_tag(file_content) == ("", "", file_content)


### PR DESCRIPTION
**Bug details:**

Enrichment was failing to make replacements for for documents without header tags. Spcifically erroring with:
```
[ERROR] IndexError: list index out of range
Traceback (most recent call last):
  File "/var/task/index.py", line 219, in handler
    process_event(sqs_rec)
  File "/var/task/index.py", line 135, in process_event
    judgment_split[2], replacement_file_content
[ERROR] IndexError: list index out of range Traceback (most recent call last):   File "/var/task/index.py", line 219, in handler     process_event(sqs_rec)   File "/var/task/index.py", line 135, in process_event     judgment_split[2], replacement_file_content
```

**Changes in this PR:**

- This fixes this bug by fixing the splitting logic.
- Also refactored the main lambda function, extracting out the main logic away from the s3 code and removed unnecessary noisy print statements that were making the logs horrible to go through and debug.

Still need to:
- Write a test for the newly extracted logic function