### PR TITLE
Run pre-commit in CI to check things, instead of firing them individually

### DIFF
--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -22,9 +22,29 @@ defaults:
     shell: bash
 
 jobs:
-  source_lint_and_test:
-    runs-on: ubuntu-latest
 
+  run-pre-commit:
+    name: Run pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: |
+            requirements/base.txt
+            requirements/local.txt
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+        
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.1
@@ -35,18 +55,6 @@ jobs:
         uses: actions/setup-python@v4.7.1
         with:
           python-version: 3.9
-
-      - name: pip install formatting dependencies
-        run: |
-          pip3 install black==22.8.0 isort
-
-      - name: Python Black Formatting Check
-        id: run_python_black
-        run: black . --extend-exclude "^/get-pip.py" --check --diff
-
-      - name: Python isort Order Check
-        id: run_python_isort
-        run: isort . -s "get-pip.py" --check --diff
 
       - name: pip install tests dependencies
         run: |

--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
-        
+
   run-tests:
     name: Run tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -30,15 +30,6 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4.7.1
-        with:
-          python-version: "3.9"
-          cache: pip
-          cache-dependency-path: |
-            requirements/base.txt
-            requirements/local.txt
-
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,19 +2,19 @@ default_stages: [commit]
 
 repos:
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.2
+    rev: v2.2.1
     hooks:
     - id: autoflake
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.11.0
     hooks:
       - id: black
 
@@ -25,24 +25,24 @@ repos:
         # args: ["--profile", "black"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
+    rev: 0.7.17
     hooks:
       - id: mdformat
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.83.5
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1  # Use the sha / tag you want to point at
+    rev: v1.7.0  # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         args: [--explicit-package-bases]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.2.1
     hooks:
-    - id: autoflake
+      - id: autoflake
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -34,15 +34,21 @@ repos:
     rev: 0.7.17
     hooks:
       - id: mdformat
+        exclude: "terraform/README.md"
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.5
     hooks:
       - id: terraform_fmt
-      - id: terraform_docs
+
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: v0.16.0
+    hooks:
+      - id: terraform-docs-go
+        args: ["markdown", "table", "--output-file", "README.md", "./terraform"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.0  # Use the sha / tag you want to point at
+    rev: v1.7.0 # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         args: [--explicit-package-bases]

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The VCite integration is shown more distinctly in the diagram below:
 CI/CD works in the following way:
 
 - Engineer branches from `main` branch, commits code and raises a pull request.
-  - The Python code within the repo is checked against formatting tools called `black` and `isort`.
+  - The code within the repo is checked using the tools defined in `.pre-commit-config.yaml`.
   - The Terraform code is checked against a linting tool called `TFLint`.
   - Terraform is validated and planned against staging and production as independent checks.
 - Upon merge, non dockerised lambdas are built, terraform is planned, applied and then docker images are built and pushed to ECR. This occurs for staging, if staging succeeds then the same happens for production.
@@ -140,11 +140,7 @@ CI/CD works in the following way:
   - Terraform Validate
   - Terraform init.
   - Terraform Plan (A plan of the infrastructure changes for that environment)
-* If the checks fail due to Python Black.
-  A message such as `Oh no! 💥 💔 💥 13 files would be reformatted, 5 files would be left unchanged.`
-  - To fix this, install black locally `pip install black`, then run `black .` and commit the reformatted code.
-* If the check fails due to iSort. A message such as `ERROR: Imports are incorrectly sorted.`
-  - To fix this, install isort locally `pip install isort`, then run `isort .`
+* If the checks fail at the pre-commit stage you can usually fix these with `pre-commit run --all-files` and committing the changes. Problems which can't be auto-fixed will be explained.
 * TFLint will explain any errors it finds.
 * Terraform plan needs to be inspected before merging code to ensure the right thing is being applied.
   Do not assume that a green build is going to build what you want to be built.
@@ -166,6 +162,8 @@ Here are some brief notes on extending the infrastructure.
 - Adding an S3 bucket is done by invoking the `secure_bucket` module, located at `terraform/modules/secure_bucket/`, you can see how the existing buckets are created by viewing `terraform/modules/lambda_s3/bucket.tf`, new buckets should be created by adding to this file.
   If a bucket policy is added, then an extra statement will automatically be added that denies insecure transport.
 - Docker images are stored in ECR. Each repo needs to exist before a docker image can be pushed to ECR. These are created in `terraform/modules/lambda_s3/lambda.tf`.
+
+You can find auto-generated documentation on the Terraform resources in [terraform/README.md](/terraform/README.md).
 
 ### Updating the .terraform.lock.hcl file
 

--- a/caselaw-ontology/examples/core-pipeline/2019-ewhc-1-costs-rdf-example.ttl
+++ b/caselaw-ontology/examples/core-pipeline/2019-ewhc-1-costs-rdf-example.ttl
@@ -6,7 +6,7 @@
 @prefix leg: <http://www.legislation.gov.uk/def/legislation/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# This RDF is based on what could be easily extracted from the XML document.  
+# This RDF is based on what could be easily extracted from the XML document.
 # There are other things not included here that could be extracted which are not as clearly marked up - case parties, judges, etc
 
 
@@ -32,7 +32,7 @@
     :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/47.3> ;
     :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/47.11> ;
     :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/47.14> ;
-    :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/47.16> ;  
+    :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/47.16> ;
     :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/48.8> ;
     :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/article/48.10> ;
     :cites           <https://www.legislation.gov.uk/id/uksi/1998/3132/part/7> ;
@@ -144,8 +144,3 @@
 
 <https://www.legislation.gov.uk/id/uksi/1998/3132/article/46.9> a leg:Item .
 <https://www.legislation.gov.uk/id/uksi/1998/3132/article/46.9> leg:Legislation <https://www.legislation.gov.uk/id/uksi/1998/3132> .
-
-
-
-
-

--- a/caselaw-ontology/examples/core-pipeline/tna-example.ttl
+++ b/caselaw-ontology/examples/core-pipeline/tna-example.ttl
@@ -6,7 +6,7 @@
     caselaw:neutralCitation "[2019] EWHC B1 (Costs)" ;
     caselaw:judgmentDate    "2019-01-23"^^xsd:date ;
     caselaw:Court           <http://caselaw.nationalarchives.gov.uk/def/courts/EWHC-SeniorCourtsCosts> ;
-    
+
     caselaw:cites           <https://caselaw.nationalarchives.gov.uk/report/1909/elr/2/170> ;
     caselaw:cites           <https://caselaw.nationalarchives.gov.uk/ewhc/ch/2005/1733> ;
     caselaw:cites           <https://caselaw.nationalarchives.gov.uk/ewhc/ch/2007/2733> ;

--- a/src/utils/tests/test_environment_helpers.py
+++ b/src/utils/tests/test_environment_helpers.py
@@ -1,7 +1,6 @@
 """Unit tests for environment_helpers"""
 
 import pytest
-from moto import mock_secretsmanager
 
 from utils.environment_helpers import get_aws_secret, validate_env_variable
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,37 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.3.0,<6.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1, <= 4.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_data"></a> [data](#module\_data) | ./modules/data | n/a |
+| <a name="module_lambda_s3"></a> [lambda\_s3](#module\_lambda\_s3) | ./modules/lambda_s3 | n/a |
+| <a name="module_network"></a> [network](#module\_network) | ./modules/network | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_env"></a> [app\_env](#input\_app\_env) | Common prefix for all Terraform created resources | `string` | `"staging"` | no |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | n/a | `string` | `"sg"` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region to deploy to | `string` | `"eu-west-2"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
This simplifies the test task by removing a bunch of independent tasks into a single "run pre-commit" job. This also improves parity between the checks run locally at commit-time and those running on CI.