### PR TITLE
Revert "Update public.ecr.aws/lambda/python Docker tag to v3.12"

### DIFF
--- a/src/lambdas/db_backup/dockerfile
+++ b/src/lambdas/db_backup/dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 

--- a/src/lambdas/determine_legislation_provisions/Dockerfile
+++ b/src/lambdas/determine_legislation_provisions/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 # FROM public.ecr.aws/lambda/python:3.8
 # Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
 # FROM lambci/lambda:build-python3.6

--- a/src/lambdas/determine_oblique_references/Dockerfile
+++ b/src/lambdas/determine_oblique_references/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 
 # Copy only the requirements file first and install dependencies
 COPY requirements.txt ${LAMBDA_TASK_ROOT}

--- a/src/lambdas/determine_replacements_abbreviations/Dockerfile
+++ b/src/lambdas/determine_replacements_abbreviations/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 # FROM public.ecr.aws/lambda/python:3.8
 # Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
 # FROM lambci/lambda:build-python3.6

--- a/src/lambdas/determine_replacements_caselaw/Dockerfile
+++ b/src/lambdas/determine_replacements_caselaw/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 # FROM public.ecr.aws/lambda/python:3.8
 # Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
 # FROM lambci/lambda:build-python3.6

--- a/src/lambdas/determine_replacements_legislation/Dockerfile
+++ b/src/lambdas/determine_replacements_legislation/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 # FROM public.ecr.aws/lambda/python:3.8
 # Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
 # FROM lambci/lambda:build-python3.6

--- a/src/lambdas/fetch_xml/dockerfile
+++ b/src/lambdas/fetch_xml/dockerfile
@@ -16,7 +16,7 @@
 
 ### TRY THIS CODE INSTEAD
 
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 

--- a/src/lambdas/push_enriched_xml/dockerfile
+++ b/src/lambdas/push_enriched_xml/dockerfile
@@ -16,7 +16,7 @@
 
 ### TRY THIS CODE INSTEAD
 
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.9
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 

--- a/src/lambdas/update_legislation_table/Dockerfile
+++ b/src/lambdas/update_legislation_table/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.8
 
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
 

--- a/src/lambdas/update_rules_processor/Dockerfile
+++ b/src/lambdas/update_rules_processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.8
 
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
 


### PR DESCRIPTION
This reverts commit 5ee688f2b7e805e3df99e72cde70ebbfc833777a.

Revert python-in-docker-containers to 3.8 and 3.9 to see if that impacts the ingester errors we've been getting.