### PR TITLE
Actually use Python 3.12 everywhere

### DIFF
--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: pip install tests dependencies
         run: |

--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: 3.12
+          python-version: "3.12"
 
       - name: pip install tests dependencies
         run: |

--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: 3.12
+          python-version: "3.12"
 
       - name: Get AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Get AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ force_grid_wrap = 0
 use_parentheses = true
 
 [mypy]
-python_version = 3.9
+python_version = 3.12
 check_untyped_defs = True
 ignore_missing_imports = True
 warn_unused_ignores = True

--- a/src/abbreviation_extraction/requirements.txt
+++ b/src/abbreviation_extraction/requirements.txt
@@ -1,2 +1,2 @@
 spacy==3.7.2
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl

--- a/src/caselaw_extraction/requirements.txt
+++ b/src/caselaw_extraction/requirements.txt
@@ -1,5 +1,5 @@
 spacy==3.7.2
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 pandas==1.5.3
 # pandas==1.1.5
 # psycopg2==2.9.3

--- a/src/lambdas/determine_legislation_provisions/Dockerfile
+++ b/src/lambdas/determine_legislation_provisions/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/lambda/python:3.12
-# FROM public.ecr.aws/lambda/python:3.8
+# FROM public.ecr.aws/lambda/python:3.12
 # Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
 # FROM lambci/lambda:build-python3.6
 # FROM public.ecr.aws/lambda/python:3.6

--- a/src/lambdas/determine_replacements_abbreviations/Dockerfile
+++ b/src/lambdas/determine_replacements_abbreviations/Dockerfile
@@ -1,9 +1,5 @@
 
 FROM public.ecr.aws/lambda/python:3.12
-# FROM public.ecr.aws/lambda/python:3.8
-# Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
-# FROM lambci/lambda:build-python3.6
-# FROM public.ecr.aws/lambda/python:3.6
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 # Set the timezone

--- a/src/lambdas/determine_replacements_caselaw/Dockerfile
+++ b/src/lambdas/determine_replacements_caselaw/Dockerfile
@@ -1,9 +1,5 @@
 
 FROM public.ecr.aws/lambda/python:3.12
-# FROM public.ecr.aws/lambda/python:3.8
-# Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
-# FROM lambci/lambda:build-python3.6
-# FROM public.ecr.aws/lambda/python:3.6
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 # Set the timezone

--- a/src/lambdas/determine_replacements_legislation/Dockerfile
+++ b/src/lambdas/determine_replacements_legislation/Dockerfile
@@ -1,9 +1,5 @@
 
 FROM public.ecr.aws/lambda/python:3.12
-# FROM public.ecr.aws/lambda/python:3.8
-# Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
-# FROM lambci/lambda:build-python3.6
-# FROM public.ecr.aws/lambda/python:3.6
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 # Set the timezone

--- a/src/lambdas/fetch_xml/dockerfile
+++ b/src/lambdas/fetch_xml/dockerfile
@@ -1,4 +1,4 @@
-# FROM public.ecr.aws/lambda/python:3.9
+# FROM public.ecr.aws/lambda/python:3.12
 
 # WORKDIR /
 

--- a/src/lambdas/push_enriched_xml/dockerfile
+++ b/src/lambdas/push_enriched_xml/dockerfile
@@ -1,4 +1,4 @@
-# FROM public.ecr.aws/lambda/python:3.9
+# FROM public.ecr.aws/lambda/python:3.12
 
 # WORKDIR /
 

--- a/src/lambdas/update_rules_processor/requirements.txt
+++ b/src/lambdas/update_rules_processor/requirements.txt
@@ -3,4 +3,4 @@ pandas==1.5.3
 sqlalchemy==1.4.50
 boto3==1.28.85
 spacy==3.7.2
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl

--- a/src/legislation_extraction/legislation_matcher_hybrid.py
+++ b/src/legislation_extraction/legislation_matcher_hybrid.py
@@ -175,7 +175,7 @@ def search_for_act_fuzzy(title, docobj, nlp, cutoff, candidates=None):
     fuzzy_matcher.add("Text Extractor", phrase_list, kwargs=[options])
     matched_items = fuzzy_matcher(docobj)
     matched_text = []
-    for _, start, end, ratio in matched_items:
+    for _, start, end, ratio, pattern in matched_items:
         span = docobj[start:end]
         matched_text.append((span.text, start, end, ratio))
     return matched_text

--- a/src/legislation_extraction/requirements.txt
+++ b/src/legislation_extraction/requirements.txt
@@ -1,5 +1,5 @@
 spacy==3.7.2
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 spaczz==0.6.0
 pandas==1.5.3
 # psycopg2==2.9.3

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -4,7 +4,7 @@ pandas==1.4.1
 psycopg2==2.9.5
 beautifulsoup4==4.11.2
 spaczz==0.5.4
-lxml==4.9.2
+lxml==4.9.3
 testing.postgresql==1.3.0
 sqlalchemy==2.0.4
 coverage==7.2.1

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -16,4 +16,4 @@ pytest-postgresql==4.1.1
 psycopg==3.1.8
 SPARQLWrapper==2.0.0
 python-dotenv==1.0.0
-rapidfuzz==3.5.2
+rapidfuzz==2.15.2

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -16,3 +16,4 @@ pytest-postgresql==4.1.1
 psycopg==3.1.8
 SPARQLWrapper==2.0.0
 python-dotenv==1.0.0
+rapidfuzz==3.5.2

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -1,4 +1,4 @@
-spacy==3.2.6
+spacy==3.7.2
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pandas==1.4.1
 psycopg2==2.9.5

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -1,5 +1,5 @@
 spacy==3.7.2
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 pandas==1.4.1
 psycopg2==2.9.5
 beautifulsoup4==4.11.2

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -3,7 +3,7 @@ en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_
 pandas==1.4.1
 psycopg2==2.9.5
 beautifulsoup4==4.11.2
-spaczz==0.5.4
+spaczz==0.6.0
 lxml==4.9.3
 testing.postgresql==1.3.0
 sqlalchemy==2.0.4

--- a/terraform/modules/lambda_s3/lambda.tf
+++ b/terraform/modules/lambda_s3/lambda.tf
@@ -8,7 +8,7 @@ module "lambda-extract-judgement-contents" {
 
   # Deploy as code
   handler     = "index.handler"
-  runtime     = "python3.9"
+  runtime     = "python3.12"
   source_path = "${var.lambda_source_path}extract_judgement_contents"
 
   create_current_version_allowed_triggers = false # !var.use_container_image
@@ -768,7 +768,7 @@ module "lambda-make-replacements" {
   package_type  = var.use_container_image == true ? "Image" : "Zip"
 
   handler = "index.handler"
-  runtime = "python3.9"
+  runtime = "python3.12"
 
   source_path = "${var.lambda_source_path}make_replacements"
 
@@ -941,7 +941,7 @@ module "lambda-update-legislation-table" {
   function_name = "${local.name}-${local.environment}-update-legislation-table"
   package_type  = var.use_container_image == true ? "Image" : "Zip"
 
-  runtime = "python3.9" # Setting runtime is required when building package in Docker and Lambda Layer resource.
+  runtime = "python3.12" # Setting runtime is required when building package in Docker and Lambda Layer resource.
 
   # Deploy as code
   handler = "index.handler"
@@ -1028,7 +1028,7 @@ module "lambda-update-rules-processor" {
   package_type   = "Image"
   create_package = false
 
-  runtime = "python3.8" # Setting runtime is required when building package in Docker and Lambda Layer resource.
+  runtime = "python3.12" # Setting runtime is required when building package in Docker and Lambda Layer resource.
 
   image_uri = "${aws_ecr_repository.rules-update.repository_url}:${var.container_image_tag}"
 
@@ -1153,7 +1153,7 @@ module "lambda-validate-replacements" {
   # Deploy as code
   handler = "index.handler"
 
-  runtime     = "python3.9"
+  runtime     = "python3.12"
   source_path = "${var.lambda_source_path}xml_validate"
 
   create_current_version_allowed_triggers = false # !var.use_container_image
@@ -1379,7 +1379,7 @@ module "lambda-fetch-xml" {
   package_type   = "Image"
   create_package = false
 
-  runtime = "python3.9" # Setting runtime is required when building package in Docker and Lambda Layer resource.
+  runtime = "python3.12" # Setting runtime is required when building package in Docker and Lambda Layer resource.
 
   image_uri = "${aws_ecr_repository.fetch-xml.repository_url}:${var.container_image_tag}"
 
@@ -1516,7 +1516,7 @@ module "lambda-push-enriched-xml" {
   package_type   = "Image"
   create_package = false
 
-  runtime = "python3.9" # Setting runtime is required when building package in Docker and Lambda Layer resource.
+  runtime = "python3.12" # Setting runtime is required when building package in Docker and Lambda Layer resource.
 
   image_uri = "${aws_ecr_repository.push_enriched_xml.repository_url}:${var.container_image_tag}"
 

--- a/terraform/modules/lambda_s3/variables.tf
+++ b/terraform/modules/lambda_s3/variables.tf
@@ -56,7 +56,7 @@ variable "lambda_handler" {
 
 variable "runtime" {
   type    = string
-  default = "python3.8"
+  default = "python3.12"
 }
 
 variable "lambda_source_path" {


### PR DESCRIPTION
We updated to Python 3.12 in some places, but not everywhere. This is a likely contributor to things not working.

Move all references to Python 3.12 and then fix the fallout.