### PR TITLE
Renovate test requirements.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
-  "pip_requirements": {
-    "fileMatch": ["src/tests/requirements\\.txt"]
-  }
+  "ignoreModulesAndTests": {
+    "description": "Don't ignore tests directory. See https://github.com/renovatebot/renovate/discussions/12755",
+    "ignorePaths": []
 }


### PR DESCRIPTION
Renovate skips some directories: see https://github.com/renovatebot/renovate/discussions/12755
No idea if this actually works.