### PR TITLE
Fix Renovate ignore config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
-  "ignoreModulesAndTests": {
-    "description": "Don't ignore tests directory. See https://github.com/renovatebot/renovate/discussions/12755",
-    "ignorePaths": []
-  }
+  "ignorePaths": []
 }


### PR DESCRIPTION
We want an empty ignore list, so that dependencies in tests are properly updated.