### PR TITLE
Move to integer based versioning and fix "no year" case for refs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+- \[ \] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
+- \[ \] Update CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+1: Ensure "No Year" does not appear in <ref> tags to avoid validation errors.
+
+0.1.0: Before December 2023, versions were not tracked and the version string was "0.1.0"

--- a/README.md
+++ b/README.md
@@ -239,3 +239,17 @@ You can find all the s3 bucket names where they are defined in `terraform/module
 ### Recreate and debug
 
 Once we have determined the lambda that caused the issue, xml from the s3 buckets on either side of the lambda, and any relevant log information as a starting point, we can use the xml from each as input and expected output fixtures for an end to end test to help us debug locally with breakpoints and fix the bug.
+
+## 11 Deploy
+
+Currently, the `main` branch is deployed to staging, and if that doesn't fail, it is then deployed to production.
+
+#### Release Process
+
+The version should be an integer string (like "1"): note, however, that pre-December 2023 versions were version "0.1.0".
+
+As a part of each pull request that isn't just keeping versions up to date:
+
+- Update the version number in `enrichment_version.string` in `src/lambdas/determine_legislation_provisions/index.py`
+- Update `CHANGELOG.md` with a brief description of the change
+- Create a release on Github with a tag like `v1`. This does nothing, but is useful to help us keep track.

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -43,7 +43,7 @@ def add_timestamp_and_engine_version(file_data):
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "0.1.0"
+    enrichment_version.string = "1"
     soup.proprietary.append(enrichment_version)
     soup.FRBRManifestation.FRBRdate.insert_after(enriched_date)
 

--- a/src/replacer/replacer_pipeline.py
+++ b/src/replacer/replacer_pipeline.py
@@ -3,6 +3,20 @@ Replacer logic for first phase enrichment.
 Handles the replacements of abbreviations, legislation, and case law.
 """
 
+import re
+
+
+def fixed_year(year):
+    """For some reason, years can be returned as "No Year", despite not being present in the code (outside tests) or the database
+    (as far as I can see."""
+    if not year:
+        return None
+    match = re.search(r"\d+", year)
+    if match:
+        return match.group()
+    else:
+        return None
+
 
 def replacer_caselaw(file_data, replacement):
     """
@@ -11,7 +25,10 @@ def replacer_caselaw(file_data, replacement):
     :param replacement: tuple of citation match and corrected citation
     :return: enriched XML file data
     """
-    replacement_string = f'<ref uk:type="case" href="{replacement[3]}" uk:isNeutral="{str(replacement[4]).lower()}" uk:canonical="{replacement[1]}" uk:year="{replacement[2]}" uk:origin="TNA">{replacement[0]}</ref>'
+
+    year = fixed_year(replacement[2])
+    year_xml = f'uk:year="{year}" ' if year else ""
+    replacement_string = f'<ref uk:type="case" href="{replacement[3]}" uk:isNeutral="{str(replacement[4]).lower()}" uk:canonical="{replacement[1]}" {year_xml}uk:origin="TNA">{replacement[0]}</ref>'
     file_data = str(file_data).replace(replacement[0], replacement_string)
     return file_data
 

--- a/src/tests/lambda_tests/determine_legislation_provisions/test_determine_legislation_provisions.py
+++ b/src/tests/lambda_tests/determine_legislation_provisions/test_determine_legislation_provisions.py
@@ -22,7 +22,7 @@ def xml_valid_and_can_get_version(xml):
         "//example:tna-enrichment-engine/text()",
         namespaces={"example": "https://caselaw.nationalarchives.gov.uk/akn"},
     )[0]
-    return re.search(r"\d+\.\d+\.\d+", version)
+    return re.search(r"\d[\d\.]*", version)
 
 
 def test_engine_version_valid_xml_without_namespace_is_valid():

--- a/src/tests/replacer_tests/test_replacer_pipeline.py
+++ b/src/tests/replacer_tests/test_replacer_pipeline.py
@@ -12,7 +12,7 @@ class TestCitationReplacer(unittest.TestCase):
     This class tests the replacement of the citations within the text itself. This comes from shared.replacer.py
     """
 
-    def test_citation_replacer(self):
+    def test_citation_replacer_1(self):
         citation_match = "[2025] 1 All E.R. 123"  # incorrect citation
         corrected_citation = (
             "[2025] 1 All ER 123"  # in practice, returned via the citation matcher
@@ -29,6 +29,7 @@ class TestCitationReplacer(unittest.TestCase):
         )
         assert replacement_string in replaced_entry
 
+    def test_citation_replacer_2(self):
         citation_match = "[2022] UKET 789123_2012"
         corrected_citation = "[2022] UKET 789123/2012"
         year = "2022"
@@ -43,6 +44,7 @@ class TestCitationReplacer(unittest.TestCase):
         )
         assert replacement_string in replaced_entry
 
+    def test_citation_replacer_3(self):
         citation_match = "LR 1 A&E 123"
         corrected_citation = "LR 1 AE 123"
         year = "No Year"
@@ -57,6 +59,7 @@ class TestCitationReplacer(unittest.TestCase):
         )
         assert replacement_string in replaced_entry
 
+    def test_citation_replacer_4(self):
         citation_match = "(2022) EWHC 123 (Mercantile)"
         corrected_citation = "[2022] EWHC 123 (Mercantile)"
         year = "2022"
@@ -71,6 +74,7 @@ class TestCitationReplacer(unittest.TestCase):
         )
         assert replacement_string in replaced_entry
 
+    def test_citation_replacer_5(self):
         citation_match = "[2022] ewca civ 123"
         corrected_citation = "[2022] EWCA Civ 123"
         year = "2022"
@@ -91,7 +95,7 @@ class TestLegislationReplacer(unittest.TestCase):
     This class tests the replacement of the citations within the text itself. This comes from shared.replacer.py
     """
 
-    def test_citation_replacer(self):
+    def test_citation_replacer_1(self):
         legislation_match = "Adoption and Children Act 2002"  # matched legislation
         href = "http://www.legislation.gov.uk/ukpga/2002/38"
         text = "In their skeleton argument in support of the first ground, Mr Goodwin and Mr Redmond remind the court that the welfare checklist in s.1(4) of the Adoption and Children Act 2002 requires the court, inter alia"
@@ -102,6 +106,7 @@ class TestLegislationReplacer(unittest.TestCase):
         replacement_string = '<ref uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2002/38" uk:canonical="foo" uk:origin="TNA">Adoption and Children Act 2002</ref>'
         assert replacement_string in replaced_entry
 
+    def test_citation_replacer_2(self):
         legislation_match = "Children and Families Act 2014"  # matched legislation
         href = "http://www.legislation.gov.uk/ukpga/2014/6/enacted"
         text = "In her first judgment on 31 January, the judge correctly directed herself as to the law, reminding herself that any application for expert evidence in children’s proceedings is governed by s.13 of the Children and Families Act 2014."

--- a/src/tests/replacer_tests/test_replacer_pipeline.py
+++ b/src/tests/replacer_tests/test_replacer_pipeline.py
@@ -1,6 +1,7 @@
 import unittest
 
 from replacer.replacer_pipeline import (
+    fixed_year,
     replacer_abbr,
     replacer_caselaw,
     replacer_leg,
@@ -44,7 +45,8 @@ class TestCitationReplacer(unittest.TestCase):
         )
         assert replacement_string in replaced_entry
 
-    def test_citation_replacer_3(self):
+    def test_citation_replacer_3_no_year(self):
+        """Note that this test does not have a year, so there is no uk:year attribute, unlike the others"""
         citation_match = "LR 1 A&E 123"
         corrected_citation = "LR 1 AE 123"
         year = "No Year"
@@ -54,9 +56,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
-            URI, is_neutral, corrected_citation, year, citation_match
-        )
+        replacement_string = f'<ref uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:origin="TNA">{citation_match}</ref>'
         assert replacement_string in replaced_entry
 
     def test_citation_replacer_4(self):
@@ -140,3 +140,21 @@ class TestReplacerAbbr(unittest.TestCase):
             "</abbr>"
         )
         assert replacer_abbr(text, replacement_entry) == expected
+
+
+class TestFixedYear(unittest.TestCase):
+    def test_no_year(self):
+        assert fixed_year(None) == None
+
+    def test_empty_year(self):
+        assert fixed_year("") == None
+
+    def test_gibberish_year(self):
+        assert fixed_year("xxx") == None
+
+    def test_real_year(self):
+        assert fixed_year("1969") == "1969"
+
+    def test_mixed_year(self):
+        """This shouldn't be used anywhere, it's merely documenting the behaviour added whilst fixing the No Year issue"""
+        assert fixed_year("In the summer of '69") == "69"


### PR DESCRIPTION
`<ref>` tags were being emitted with `uk:year="No Year"`. Whilst it's not clear where the `No Year` is coming from (the database doesn't seem to have it, nor does the code) we detect non-year containing strings and do not provide a `uk:year` attribute at all.

We also set up groundwork for a versioning scheme.