### PR TITLE
Run CI in merge queue

### DIFF
--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
We should use merge queues to streamline getting lots of PRs in for dependency updates without running the (very expensive) build process over and over.