### PR TITLE
Swap deprecated is_enabled argument for state

### DIFF
--- a/terraform/modules/lambda_s3/eb.tf
+++ b/terraform/modules/lambda_s3/eb.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "db_backup" {
   name                = "db-backup"
   description         = "Trigger lambda to perform db snapshot"
-  is_enabled          = true # update last
+  state               = "ENABLED"
   schedule_expression = "cron(0 12 * * ? *)"
 }
 


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#argument-reference

```
Warning: Argument is deprecated

  with module.lambda_s3.aws_cloudwatch_event_rule.db_backup,
  on modules/lambda_s3/eb.tf line 4, in resource "aws_cloudwatch_event_rule" "db_backup":
   4:   is_enabled          = true # update last

Use "state" instead
```