### PR TITLE
Move back to semantic versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+== v3.0.0 ==
+Change the version back to semver to not violate our schema.
+
 == v2 ==
 Update Terraform to filter only trigger_enrichment messages.
 Enrichment lambdas do not attempt to filter based on body JSON.

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -43,7 +43,7 @@ def add_timestamp_and_engine_version(file_data):
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "2"
+    enrichment_version.string = "3.0.0"
     soup.proprietary.append(enrichment_version)
     soup.FRBRManifestation.FRBRdate.insert_after(enriched_date)
 


### PR DESCRIPTION
Whilst there are advantages to having a single number for working out whether a version is new or not (cast to int, done) it is not that much more conceptually difficult to check the major part of the version number, and that does not violate the schema. Whilst it's likely no-one is using it, we probably shouldn't just change it.

- \[x\] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- \[x\] Update CHANGELOG.md
