### PR TITLE
Ensure that press-summary URLs come out unchanged

### DIFF
--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -25,6 +25,11 @@ def validate_env_variable(env_var_name):
     return env_variable
 
 
+def fcl_uri(source_key):
+    slashed = source_key.replace("-", "/").split(".")[0]
+    return slashed.replace("press/summary", "press-summary")
+
+
 ############################################
 # - API FUNCTIONS
 ############################################
@@ -115,7 +120,7 @@ def process_event(sqs_rec):
     )
 
     print(source_key)
-    judgment_uri = source_key.replace("-", "/").split(".")[0]
+    judgment_uri = fcl_uri(source_key)
     print(judgment_uri)
 
     # patch the judgment

--- a/src/tests/lambda_tests/push_enriched/test_push_enriched.py
+++ b/src/tests/lambda_tests/push_enriched/test_push_enriched.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_env():
+    os.environ["SOURCE_BUCKET"] = "1"
+    os.environ["API_PASSWORD"] = "1"
+    os.environ["API_USERNAME"] = "1"
+    os.environ["ENVIRONMENT"] = "1"
+
+
+def test_fcl_uri():
+    # currently we need to set the environment variables before we import the module.
+    from lambdas.push_enriched_xml.index import fcl_uri
+
+    assert fcl_uri("ewhc-ch-2023-1") == "ewhc/ch/2023/1"
+    assert fcl_uri("ewhc-ch-2023-1-press-summary-1") == "ewhc/ch/2023/1/press-summary/1"


### PR DESCRIPTION
Enrichment uses hyphen separated URLs, but this leads to ambiguity when incoming ewhc/2023/1/press-summary/1 URLs have a mixture of slashes and hyphens. Special case it for now.