### PR TITLE
Better XML generation -- 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+== v5.0.0 ==
+Create `create_tag` and `create_tag_string` to make more compliant XML, to try to resolve escaping issues.
+Escape some strings coming from the replacement lists on output
+
 == v4.0.0 ==
 Fix a bug which was mangling judgment text in particular scenarios when inserting references.
 

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -43,7 +43,7 @@ def add_timestamp_and_engine_version(file_data):
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "4.0.0"
+    enrichment_version.string = "5.0.0"
     soup.proprietary.append(enrichment_version)
     soup.FRBRManifestation.FRBRdate.insert_after(enriched_date)
 

--- a/src/legislation_provisions_extraction/legislation_provisions.py
+++ b/src/legislation_provisions_extraction/legislation_provisions.py
@@ -12,13 +12,14 @@ To do:
 2. "Section 27(A)" - currently miss these references when replacing
 3. Sub-sections aren't being replaced
 """
-
 import os
 import re
 from typing import Any, Dict, List
 
 import numpy as np
 from bs4 import BeautifulSoup
+
+from utils.proper_xml import create_tag_string
 
 SectionDict = Dict[str, List[Any]]  # this is a guess
 
@@ -151,7 +152,16 @@ def create_section_ref_tag(section_dict, match):
     """
     canonical = section_dict["section_canonical"]
     href = section_dict["section_href"]
-    section_ref = f'<ref uk:type="legislation" href="{href}" uk:canonical="{canonical}" uk:origin="TNA">{match.strip()}</ref>'
+    section_ref = create_tag_string(
+        "ref",
+        match.strip(),
+        {
+            "uk:type": "legislation",
+            "href": href,
+            "uk:canonical": canonical,
+            "uk:origin": "TNA",
+        },
+    )
     return section_ref
 
 

--- a/src/oblique_references/oblique_references.py
+++ b/src/oblique_references/oblique_references.py
@@ -20,8 +20,9 @@ The pipeline returns a dictionary containing the detected oblique reference, its
 """
 
 import re
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+import lxml.etree
 from bs4 import BeautifulSoup
 
 patterns = {
@@ -146,6 +147,16 @@ def match_act(
     return matched_act
 
 
+def make_valid_tag(
+    tag: str, body: Optional[str] = None, attrs: Optional[dict[str, str]] = None
+) -> str:
+    if not attrs:
+        attrs = {}
+    element = lxml.etree.Element(tag, attrs)
+    element.text = body
+    return lxml.etree.tostring(element)
+
+
 def create_section_ref_tag(replacement_dict: LegislationDict, match: str) -> str:
     """
     Create replacement string for detected oblique reference
@@ -159,6 +170,8 @@ def create_section_ref_tag(replacement_dict: LegislationDict, match: str) -> str
         f'<ref href="{href}" uk:canonical="{canonical}" '
         f'uk:type="legislation" uk:origin="TNA">{match.strip()}</ref>'
     )
+
+    #  make_tag(tag="ref", body = match.strip(), attrs={"href": href, "uk:canonical": canonical, 'uk:type': 'legislation', 'uk:origin':'TNA'})
 
     return oblique_ref
 

--- a/src/oblique_references/oblique_references.py
+++ b/src/oblique_references/oblique_references.py
@@ -20,10 +20,11 @@ The pipeline returns a dictionary containing the detected oblique reference, its
 """
 
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
-import lxml.etree
 from bs4 import BeautifulSoup
+
+from utils.proper_xml import create_tag_string
 
 patterns = {
     "legislation": r"<ref(((?!ref>).)*)type=\"legislation\"(.*?)ref>",
@@ -147,16 +148,6 @@ def match_act(
     return matched_act
 
 
-def make_valid_tag(
-    tag: str, body: Optional[str] = None, attrs: Optional[dict[str, str]] = None
-) -> str:
-    if not attrs:
-        attrs = {}
-    element = lxml.etree.Element(tag, attrs)
-    element.text = body
-    return lxml.etree.tostring(element)
-
-
 def create_section_ref_tag(replacement_dict: LegislationDict, match: str) -> str:
     """
     Create replacement string for detected oblique reference
@@ -166,13 +157,16 @@ def create_section_ref_tag(replacement_dict: LegislationDict, match: str) -> str
     """
     canonical = replacement_dict["canonical"]
     href = replacement_dict["href"]
-    oblique_ref = (
-        f'<ref href="{href}" uk:canonical="{canonical}" '
-        f'uk:type="legislation" uk:origin="TNA">{match.strip()}</ref>'
+    oblique_ref = create_tag_string(
+        "ref",
+        match.strip(),
+        {
+            "href": href,
+            "uk:canonical": canonical,
+            "uk:type": "legislation",
+            "uk:origin": "TNA",
+        },
     )
-
-    #  make_tag(tag="ref", body = match.strip(), attrs={"href": href, "uk:canonical": canonical, 'uk:type': 'legislation', 'uk:origin':'TNA'})
-
     return oblique_ref
 
 

--- a/src/replacer/replacer_pipeline.py
+++ b/src/replacer/replacer_pipeline.py
@@ -3,7 +3,10 @@ Replacer logic for first phase enrichment.
 Handles the replacements of abbreviations, legislation, and case law.
 """
 
+import html
 import re
+
+from utils.proper_xml import create_tag_string
 
 
 def fixed_year(year):
@@ -27,8 +30,17 @@ def replacer_caselaw(file_data, replacement):
     """
 
     year = fixed_year(replacement[2])
-    year_xml = f'uk:year="{year}" ' if year else ""
-    replacement_string = f'<ref uk:type="case" href="{replacement[3]}" uk:isNeutral="{str(replacement[4]).lower()}" uk:canonical="{replacement[1]}" {year_xml}uk:origin="TNA">{replacement[0]}</ref>'
+    attribs = {
+        "uk:type": "case",
+        "href": replacement[3],
+        "uk:isNeutral": str(replacement[4]).lower(),
+        "uk:canonical": replacement[1],
+    }
+    if year:
+        attribs["uk:year"] = year
+    attribs["uk:origin"] = "TNA"
+    replacement_string = create_tag_string("ref", html.escape(replacement[0]), attribs)
+
     file_data = str(file_data).replace(replacement[0], replacement_string)
     return file_data
 
@@ -40,7 +52,13 @@ def replacer_leg(file_data, replacement):
     :param replacement: tuple of citation match and corrected citation
     :return: enriched XML file data
     """
-    replacement_string = f'<ref uk:type="legislation" href="{replacement[1]}" uk:canonical="{replacement[2]}" uk:origin="TNA">{replacement[0]}</ref>'
+    attribs = {
+        "uk:type": "legislation",
+        "href": replacement[1],
+        "uk:canonical": replacement[2],
+        "uk:origin": "TNA",
+    }
+    replacement_string = create_tag_string("ref", html.escape(replacement[0]), attribs)
     file_data = str(file_data).replace(replacement[0], replacement_string)
     return file_data
 

--- a/src/tests/legislation_provision_extraction_tests/test_legislation_provisions.py
+++ b/src/tests/legislation_provision_extraction_tests/test_legislation_provisions.py
@@ -151,7 +151,7 @@ class TestLegislationProvisionProcessor(unittest.TestCase):
                 "detected_ref": "section 41",
                 "ref_para": 1005,
                 "ref_position": 170,
-                "ref_tag": '<ref uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/Edw7/6/41/section/41" uk:canonical="1906 (6 Edw. 7) c. 41 s. 41" uk:origin="TNA">section 41</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/Edw7/6/41/section/41" uk:canonical="1906 (6 Edw. 7) c. 41 s. 41" uk:origin="TNA">section 41</ref>',
             }
         ]
         resolved_ref = provision_resolver(section_dict, match, para_number)
@@ -178,7 +178,7 @@ class TestLegislationProvisionProcessor(unittest.TestCase):
                 "detected_ref": "Section 1(1)",
                 "ref_para": 202,
                 "ref_position": 950,
-                "ref_tag": '<ref uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/1977/37/section/1/1" uk:canonical="1977 c. 37 s. 1" uk:origin="TNA">Section 1(1)</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/1977/37/section/1/1" uk:canonical="1977 c. 37 s. 1" uk:origin="TNA">Section 1(1)</ref>',
             }
         ]
         resolved_ref = provision_resolver(section_dict, match, para_number)
@@ -235,13 +235,13 @@ class TestLegislationProvisionProcessor(unittest.TestCase):
                 "detected_ref": "Section 2(1)",
                 "ref_para": 205,
                 "ref_position": 404,
-                "ref_tag": '<ref uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/1977/37/section/2/1" uk:canonical="1977 c. 37 s. 2" uk:origin="TNA">Section 2(1)</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/1977/37/section/2/1" uk:canonical="1977 c. 37 s. 2" uk:origin="TNA">Section 2(1)</ref>',
             },
             {
                 "detected_ref": "Section 2(2)",
                 "ref_para": 205,
                 "ref_position": 654,
-                "ref_tag": '<ref uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/1977/37/section/2/2" uk:canonical="1977 c. 37 s. 2" uk:origin="TNA">Section 2(2)</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/id/ukpga/1977/37/section/2/2" uk:canonical="1977 c. 37 s. 2" uk:origin="TNA">Section 2(2)</ref>',
             },
         ]
         resolved_ref = provision_resolver(section_dict, match, para_number)

--- a/src/tests/oblique_reference_extraction_tests/test_determine_and_replace_oblique_references.py
+++ b/src/tests/oblique_reference_extraction_tests/test_determine_and_replace_oblique_references.py
@@ -3,11 +3,33 @@
 import unittest
 from pathlib import Path
 
+import lxml.etree
+
 from oblique_references.enrich_oblique_references import (
     enrich_oblique_references,
 )
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
+
+
+def canonical_xml(xml_bytes):
+    """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
+    val = (
+        lxml.etree.tostring(lxml.etree.fromstring(xml_bytes), method="c14n2")
+        .replace(b"\n", b"")
+        .replace(b" ", b"")
+    )
+    return val
+
+
+def assert_equal_xml(a, b):
+    if isinstance(a, str):
+        a = a.encode("utf-8")
+
+    if isinstance(b, str):
+        b = b.encode("utf-8")
+
+    assert canonical_xml(a) == canonical_xml(b)
 
 
 class TestEnrichObliqueReferences(unittest.TestCase):
@@ -29,7 +51,7 @@ class TestEnrichObliqueReferences(unittest.TestCase):
         with open(expected_file_path, "r", encoding="utf-8") as expected_file:
             expected_enriched_content = expected_file.read()
 
-        assert enriched_content.strip() == expected_enriched_content.strip()
+        assert_equal_xml(enriched_content, expected_enriched_content)
 
 
 if __name__ == "__main__":

--- a/src/tests/oblique_reference_extraction_tests/test_oblique_references.py
+++ b/src/tests/oblique_reference_extraction_tests/test_oblique_references.py
@@ -91,25 +91,25 @@ class TestGetObliqueReferenceReplacementsByParagraph(unittest.TestCase):
                 "detected_ref": "the 2004 Act",
                 "ref_position": 487,
                 "ref_para": 100,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/2004/12" uk:canonical="2004 c. 12" uk:type="legislation" uk:origin="TNA">the 2004 Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/2004/12" uk:canonical="2004 c. 12" uk:type="legislation" uk:origin="TNA">the 2004 Act</ref>',
             },
             {
                 "detected_ref": "that Act",
                 "ref_position": 186,
                 "ref_para": 153,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/1996/14" uk:canonical="1996 c. 14" uk:type="legislation" uk:origin="TNA">that Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/1996/14" uk:canonical="1996 c. 14" uk:type="legislation" uk:origin="TNA">that Act</ref>',
             },
             {
                 "detected_ref": "that Act",
                 "ref_position": 214,
                 "ref_para": 154,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/1996/14" uk:canonical="1996 c. 14" uk:type="legislation" uk:origin="TNA">that Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/1996/14" uk:canonical="1996 c. 14" uk:type="legislation" uk:origin="TNA">that Act</ref>',
             },
             {
                 "detected_ref": "that Act",
                 "ref_position": 387,
                 "ref_para": 159,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/2020/7" uk:canonical="2020 c. 7" uk:type="legislation" uk:origin="TNA">that Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/2020/7" uk:canonical="2020 c. 7" uk:type="legislation" uk:origin="TNA">that Act</ref>',
             },
         ]
 
@@ -422,13 +422,13 @@ class TestGetReplacements(unittest.TestCase):
                 "detected_ref": "the Act",
                 "ref_position": 39069,
                 "ref_para": 2,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/1968/19" uk:canonical="1968 c. 19" uk:type="legislation" uk:origin="TNA">the Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/1968/19" uk:canonical="1968 c. 19" uk:type="legislation" uk:origin="TNA">the Act</ref>',
             },
             {
                 "detected_ref": "this Act",
                 "ref_position": 480464,
                 "ref_para": 2,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/1997/43" uk:canonical="1997 c. 43" uk:type="legislation" uk:origin="TNA">this Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/1997/43" uk:canonical="1997 c. 43" uk:type="legislation" uk:origin="TNA">this Act</ref>',
             },
         ]
         assert replacements == expected_replacements
@@ -466,13 +466,13 @@ class TestGetReplacements(unittest.TestCase):
                 "detected_ref": "the 2000 Act",
                 "ref_position": 60093,
                 "ref_para": 2,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/2000/6" uk:canonical="2000 c. 6" uk:type="legislation" uk:origin="TNA">the 2000 Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/2000/6" uk:canonical="2000 c. 6" uk:type="legislation" uk:origin="TNA">the 2000 Act</ref>',
             },
             {
                 "detected_ref": "the 2000 Act",
                 "ref_position": 560093,
                 "ref_para": 2,
-                "ref_tag": '<ref href="http://www.legislation.gov.uk/id/ukpga/2000/6" uk:canonical="2000 c. 6" uk:type="legislation" uk:origin="TNA">the 2000 Act</ref>',
+                "ref_tag": '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" href="http://www.legislation.gov.uk/id/ukpga/2000/6" uk:canonical="2000 c. 6" uk:type="legislation" uk:origin="TNA">the 2000 Act</ref>',
             },
         ]
         assert replacements == expected_replacements

--- a/src/tests/replacer_tests/test_replacer_pipeline.py
+++ b/src/tests/replacer_tests/test_replacer_pipeline.py
@@ -25,7 +25,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -40,7 +40,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -56,7 +56,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = f'<ref uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:origin="TNA">{citation_match}</ref>'
+        replacement_string = f'<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:origin="TNA">LR 1 A&amp;E 123</ref>'
         assert replacement_string in replaced_entry
 
     def test_citation_replacer_4(self):
@@ -69,7 +69,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -84,7 +84,7 @@ class TestCitationReplacer(unittest.TestCase):
         replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
         replaced_entry = replacer_caselaw(text, replacement_entry)
         assert corrected_citation in replaced_entry
-        replacement_string = '<ref uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{}" uk:isNeutral="{}" uk:canonical="{}" uk:year="{}" uk:origin="TNA">{}</ref>'.format(
             URI, is_neutral, corrected_citation, year, citation_match
         )
         assert replacement_string in replaced_entry
@@ -103,7 +103,7 @@ class TestLegislationReplacer(unittest.TestCase):
         replacement_entry = (legislation_match, href, canonical)
         replaced_entry = replacer_leg(text, replacement_entry)
         assert legislation_match in replaced_entry
-        replacement_string = '<ref uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2002/38" uk:canonical="foo" uk:origin="TNA">Adoption and Children Act 2002</ref>'
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2002/38" uk:canonical="foo" uk:origin="TNA">Adoption and Children Act 2002</ref>'
         assert replacement_string in replaced_entry
 
     def test_citation_replacer_2(self):
@@ -114,7 +114,7 @@ class TestLegislationReplacer(unittest.TestCase):
         replacement_entry = (legislation_match, href, canonical)
         replaced_entry = replacer_leg(text, replacement_entry)
         assert legislation_match in replaced_entry
-        replacement_string = '<ref uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6/enacted" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>'
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6/enacted" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>'
         assert replacement_string in replaced_entry
 
 

--- a/src/utils/proper_xml.py
+++ b/src/utils/proper_xml.py
@@ -33,4 +33,4 @@ def create_tag(
 
 
 def create_tag_string(*args, **kwargs) -> str:
-    return lxml.etree.tostring(create_tag(*args, **kwargs))
+    return lxml.etree.tostring(create_tag(*args, **kwargs)).decode("utf-8")

--- a/src/utils/proper_xml.py
+++ b/src/utils/proper_xml.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import lxml.etree
+
+namespaces = {
+    None: "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+    "uk": "https://caselaw.nationalarchives.gov.uk/akn",
+}
+
+
+def expand_namespace(namespaced_name: str) -> str:
+    if ":" not in namespaced_name:
+        return namespaced_name
+    namespace, _, name = namespaced_name.partition(":")
+    return f"{{{namespaces[namespace]}}}{name}"
+
+
+def create_tag(
+    tag: str, contents: str = "", attrs: Optional[dict[str, str]] = None
+) -> lxml.etree._Element:
+    """Create a tag with text-based contents, parsed correctly as XML"""
+    """Note that this will create bloated XML in the enrichment process, but that Marklogic will canonicalise the XML when it is ingested"""
+    if not attrs:
+        attrs = {}
+    root_start = '<root xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">'
+    root_end = "</root>"
+    xml = root_start + contents + root_end
+    root = lxml.etree.fromstring(xml)
+    root.tag = tag
+    for attr, value in attrs.items():
+        root.attrib[expand_namespace(attr)] = value
+    return root
+
+
+def create_tag_string(*args, **kwargs) -> str:
+    return lxml.etree.tostring(create_tag(*args, **kwargs))

--- a/src/utils/tests/test_proper_xml.py
+++ b/src/utils/tests/test_proper_xml.py
@@ -1,0 +1,72 @@
+import lxml.etree
+
+from utils.proper_xml import create_tag_string
+
+
+def canonical_xml(xml_bytes):
+    """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
+    val = (
+        lxml.etree.tostring(lxml.etree.fromstring(xml_bytes), method="c14n2")
+        .replace(b"\n", b"")
+        .replace(b" ", b"")
+    )
+    return val
+
+
+def assert_equal_xml(a, b):
+    if isinstance(a, str):
+        a = a.encode("utf-8")
+
+    if isinstance(a, str):
+        b = b.encode("utf-8")
+
+    assert canonical_xml(a) == canonical_xml(b)
+
+
+def test_simple_tag():
+    assert_equal_xml(
+        create_tag_string("kitten", "ocelot", {"panther": "cougar"}),
+        b'<kitten xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" panther="cougar">ocelot</kitten>',
+    )
+
+
+def test_empty_tag():
+    assert_equal_xml(
+        create_tag_string("kitten"),
+        b'<kitten xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"/>',
+    )
+
+
+def test_no_attrs():
+    assert_equal_xml(
+        create_tag_string("kitten", "ocelot"),
+        b'<kitten xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">ocelot</kitten>',
+    )
+
+
+def test_empty_with_attrs():
+    assert_equal_xml(
+        create_tag_string("kitten", attrs={"panther": "cougar"}),
+        b'<kitten xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" panther="cougar"/>',
+    )
+
+
+def test_namespaces():
+    assert_equal_xml(
+        create_tag_string("kitten", "ocelot", {"uk:panther": "cougar"}),
+        b'<kitten xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:panther="cougar">ocelot</kitten>',
+    )
+
+
+def test_nested_xml():
+    assert_equal_xml(
+        create_tag_string("kitten", "a<b>c</b>e", {"uk:panther": "cougar"}),
+        b'<kitten xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:panther="cougar">a<b>c</b>e</kitten>',
+    )
+
+
+def test_nested_xml_with_namespaces():
+    assert_equal_xml(
+        create_tag_string("kitten", "a<uk:b>c</uk:b>e", {"uk:panther": "cougar"}),
+        b'<kitten xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:panther="cougar">a<uk:b>c</uk:b>e</kitten>',
+    )

--- a/src/utils/tests/test_proper_xml.py
+++ b/src/utils/tests/test_proper_xml.py
@@ -17,7 +17,7 @@ def assert_equal_xml(a, b):
     if isinstance(a, str):
         a = a.encode("utf-8")
 
-    if isinstance(a, str):
+    if isinstance(b, str):
         b = b.encode("utf-8")
 
     assert canonical_xml(a) == canonical_xml(b)


### PR DESCRIPTION
Handle the XML replacements as actual XML (`create_tag` and `create_tag_string`), and escape some input strings that aren't from the XML.

Not sure if we should just do the string escaping separatly and maybe not do the create_tag work?

- \[x\] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- \[x\] Update CHANGELOG.md
