### PR TITLE
Add utils to deploy script for make_replacements

### DIFF
--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -46,59 +46,106 @@ jobs:
 
           cd src/
 
+          ## DETERMINE_REPLACEMENTS_CASELAW
+
           mkdir lambdas/determine_replacements_caselaw/caselaw_extraction
           cp -r caselaw_extraction/*.py lambdas/determine_replacements_caselaw/caselaw_extraction/
           cp caselaw_extraction/requirements.txt lambdas/determine_replacements_caselaw/requirements.txt
+
           mkdir lambdas/determine_replacements_caselaw/rules
           # cp caselaw_extraction/rules/citation_patterns.jsonl lambdas/determine_replacements_caselaw/rules/citation_patterns.jsonl
           # cp citation_patterns.jsonl lambdas/determine_replacements_caselaw/
           # dragon: the first of these was commented out, but could copy a file. The second cannot...
           # but we need a citations_patterns.json  in the root lambda directory, so let's make a chimera.
           cp caselaw_extraction/rules/citation_patterns.jsonl lambdas/determine_replacements_caselaw/
+
           mkdir lambdas/determine_replacements_caselaw/database
           cp -r database/*.py lambdas/determine_replacements_caselaw/database/
+
           mkdir lambdas/determine_replacements_caselaw/utils
           cp -r utils/*.py lambdas/determine_replacements_caselaw/utils/
+
+          ## XML_VALIDATE
+
           mkdir lambdas/xml_validate/utils
           cp -r utils/*.py lambdas/xml_validate/utils/
+
+          ## UPDATE_LEGISLATION_TABLE
+
           mkdir lambdas/update_legislation_table/utils
           cp -r utils/*.py lambdas/update_legislation_table/utils/
+
           mkdir lambdas/update_legislation_table/database
           cp -r database/*.py lambdas/update_legislation_table/database/
+
+          ## DETERMINE_REPLACEMENTS_LEGISLATION
+
           mkdir lambdas/determine_replacements_legislation/legislation_extraction
           cp -r legislation_extraction/*.* lambdas/determine_replacements_legislation/legislation_extraction/
           cp legislation_extraction/requirements.txt lambdas/determine_replacements_legislation/
+
           mkdir lambdas/determine_replacements_legislation/utils
           cp -r utils/*.py lambdas/determine_replacements_legislation/utils/
+
           mkdir lambdas/determine_replacements_legislation/database
           cp -r database/*.py lambdas/determine_replacements_legislation/database/
+
+          ## DETERMINE_REPLACEMENTS_ABBREVIATIONS
+
           mkdir lambdas/determine_replacements_abbreviations/abbreviation_extraction
           cp -r abbreviation_extraction/*.* lambdas/determine_replacements_abbreviations/abbreviation_extraction/
           cp abbreviation_extraction/requirements.txt lambdas/determine_replacements_abbreviations/
+
           mkdir lambdas/determine_replacements_abbreviations/utils
           cp -r utils/*.py lambdas/determine_replacements_abbreviations/utils/
+
+          ## DETERMINE_LEGISLATION_PROVISIONS
+
           mkdir lambdas/determine_legislation_provisions/legislation_provisions_extraction
           cp -r legislation_provisions_extraction/*.* lambdas/determine_legislation_provisions/legislation_provisions_extraction/
           cp legislation_provisions_extraction/requirements.txt lambdas/determine_legislation_provisions/
+
           mkdir lambdas/determine_legislation_provisions/replacer
           cp -r replacer/*.py lambdas/determine_legislation_provisions/replacer/
+
           mkdir lambdas/determine_legislation_provisions/utils
           cp -r utils/*.py lambdas/determine_legislation_provisions/utils/
+
+          ## DETERMINE_OBLIQUE_REFERENCES
+
           mkdir lambdas/determine_oblique_references/oblique_references
           cp -r oblique_references/*.* lambdas/determine_oblique_references/oblique_references/
           cp oblique_references/requirements.txt lambdas/determine_oblique_references/
+
           mkdir lambdas/determine_oblique_references/replacer
           cp -r replacer/*.py lambdas/determine_oblique_references/replacer/
+
           mkdir lambdas/determine_oblique_references/utils
           cp -r utils/*.py lambdas/determine_oblique_references/utils/
+
+          ## EXTRACT_JUDGMENT_CONTENTS
+
           mkdir lambdas/extract_judgement_contents/utils
           cp -r utils/*.py lambdas/extract_judgement_contents/utils/
+
+          ## FETCH_XML
+
           mkdir lambdas/fetch_xml/utils
           cp -r utils/*.py lambdas/fetch_xml/utils/
+
+          ## UPDATE_RULES_PROCESSOR
+
           mkdir lambdas/update_rules_processor/utils
           cp -r utils/*.py lambdas/update_rules_processor/utils/
+
           mkdir lambdas/update_rules_processor/database
           cp -r database/*.py lambdas/update_rules_processor/database/
+
+          ## MAKE_REPLACEMENTS
+
+          mkdir -p lambdas/make_replacements/utils
+          cp -r utils/*.py lambdas/make_replacements/utils/
+
           mkdir -p lambdas/make_replacements/replacer
           cp -r replacer/*.py lambdas/make_replacements/replacer/
 


### PR DESCRIPTION
We weren't including `utils` in the `make_replacements` lambda package, but couldn't easily see because the deploy script was a big block of text. This breaks it up, and adds the missing `utils`.