### PR TITLE
Fix case where `replace_references_by_paragraph` was treating XML as HTML

### DIFF
--- a/src/replacer/second_stage_replacer.py
+++ b/src/replacer/second_stage_replacer.py
@@ -7,7 +7,7 @@ Handles the replacements of oblique references and legislation provisions.
 
 import re
 from itertools import groupby
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, List, Tuple, Union
 
 from bs4 import BeautifulSoup
 
@@ -64,7 +64,10 @@ def replace_references(
     return enriched_text
 
 
-def create_replacement_paragraph(paragraph_string, paragraph_reference_replacements):
+def create_replacement_paragraph(
+    paragraph_string: str,
+    paragraph_reference_replacements: Iterable[dict[str, str | int]],
+) -> BeautifulSoup:
     replacement_paragraph_string = replace_references(
         paragraph_string, list(paragraph_reference_replacements)
     )

--- a/src/replacer/second_stage_replacer.py
+++ b/src/replacer/second_stage_replacer.py
@@ -71,7 +71,8 @@ def create_replacement_paragraph(
     replacement_paragraph_string = replace_references(
         paragraph_string, list(paragraph_reference_replacements)
     )
-    replacement_paragraph = BeautifulSoup(replacement_paragraph_string, "xml").p
+    wrapper = f'<xml xmlns:uk="placeholder">{replacement_paragraph_string}</xml>'
+    replacement_paragraph = BeautifulSoup(wrapper, "xml").p
     return replacement_paragraph
 
 

--- a/src/replacer/second_stage_replacer.py
+++ b/src/replacer/second_stage_replacer.py
@@ -64,6 +64,14 @@ def replace_references(
     return enriched_text
 
 
+def create_replacement_paragraph(paragraph_string, paragraph_reference_replacements):
+    replacement_paragraph_string = replace_references(
+        paragraph_string, list(paragraph_reference_replacements)
+    )
+    replacement_paragraph = BeautifulSoup(replacement_paragraph_string, "xml").p
+    return replacement_paragraph
+
+
 def replace_references_by_paragraph(
     file_data: BeautifulSoup, reference_replacements: LegislationReferenceReplacements
 ) -> str:
@@ -84,9 +92,9 @@ def replace_references_by_paragraph(
         ordered_reference_replacements, key=key_func
     ):
         paragraph_string = str(paragraphs[paragraph_number])
-        replacement_paragraph_string = replace_references(
-            paragraph_string, list(paragraph_reference_replacements)
+        paragraphs[paragraph_number].replace_with(
+            create_replacement_paragraph(
+                paragraph_string, paragraph_reference_replacements
+            )
         )
-        replacement_paragraph = BeautifulSoup(replacement_paragraph_string, "lxml").p
-        paragraphs[paragraph_number].replace_with(replacement_paragraph)
     return str(file_data)

--- a/src/tests/oblique_reference_extraction_tests/test_determine_and_replace_oblique_references.py
+++ b/src/tests/oblique_reference_extraction_tests/test_determine_and_replace_oblique_references.py
@@ -3,33 +3,12 @@
 import unittest
 from pathlib import Path
 
-import lxml.etree
-
 from oblique_references.enrich_oblique_references import (
     enrich_oblique_references,
 )
+from utils.tests.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
-
-
-def canonical_xml(xml_bytes):
-    """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
-    val = (
-        lxml.etree.tostring(lxml.etree.fromstring(xml_bytes), method="c14n2")
-        .replace(b"\n", b"")
-        .replace(b" ", b"")
-    )
-    return val
-
-
-def assert_equal_xml(a, b):
-    if isinstance(a, str):
-        a = a.encode("utf-8")
-
-    if isinstance(b, str):
-        b = b.encode("utf-8")
-
-    assert canonical_xml(a) == canonical_xml(b)
 
 
 class TestEnrichObliqueReferences(unittest.TestCase):

--- a/src/tests/oblique_reference_extraction_tests/test_determine_and_replace_oblique_references.py
+++ b/src/tests/oblique_reference_extraction_tests/test_determine_and_replace_oblique_references.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from oblique_references.enrich_oblique_references import (
     enrich_oblique_references,
 )
-from utils.tests.compare_xml import assert_equal_xml
+from utils.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
 

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import lxml.etree
 import pytest
 
 from replacer.make_replacments import (
@@ -8,22 +7,9 @@ from replacer.make_replacments import (
     make_post_header_replacements,
     split_text_by_closing_header_tag,
 )
+from utils.tests.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
-
-
-def canonical_xml(text):
-    """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
-    val = (
-        lxml.etree.tostring(lxml.etree.fromstring(text.encode("utf-8")), method="c14n2")
-        .replace(b"\n", b"")
-        .replace(b" ", b"")
-    )
-    return val
-
-
-def assert_xml_same(a, b):
-    assert canonical_xml(a.strip()) == canonical_xml(b.strip())
 
 
 class TestMakePostHeaderReplacements:
@@ -43,9 +29,7 @@ class TestMakePostHeaderReplacements:
         content_with_replacements = make_post_header_replacements(
             original_file_content, replacement_content
         )
-        assert canonical_xml(content_with_replacements) == canonical_xml(
-            expected_file_content.strip()
-        )
+        assert_equal_xml(content_with_replacements, expected_file_content)
 
     def test_post_header_works_if_already_enriched(self):
         original_file_content = open(
@@ -66,7 +50,7 @@ class TestMakePostHeaderReplacements:
             original_file_content, replacement_content
         )
 
-        assert_xml_same(content_with_replacements, expected_file_content)
+        assert_equal_xml(content_with_replacements, expected_file_content)
 
     def test_remove_legislation_references(self):
         tidy_output = _remove_old_enrichment_references(

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -7,7 +7,7 @@ from replacer.make_replacments import (
     make_post_header_replacements,
     split_text_by_closing_header_tag,
 )
-from utils.tests.compare_xml import assert_equal_xml
+from utils.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures/"
 

--- a/src/tests/replacer_tests/test_second_stage_replacer.py
+++ b/src/tests/replacer_tests/test_second_stage_replacer.py
@@ -9,7 +9,7 @@ from replacer.second_stage_replacer import (
     create_replacement_paragraph,
     replace_references_by_paragraph,
 )
-from utils.tests.compare_xml import assert_equal_xml
+from utils.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures"
 

--- a/src/tests/replacer_tests/test_second_stage_replacer.py
+++ b/src/tests/replacer_tests/test_second_stage_replacer.py
@@ -5,13 +5,32 @@ from pathlib import Path
 
 from bs4 import BeautifulSoup
 
-from replacer.second_stage_replacer import replace_references_by_paragraph
+from replacer.second_stage_replacer import (
+    create_replacement_paragraph,
+    replace_references_by_paragraph,
+)
 from utils.tests.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures"
 
 
 class TestSecondStageReplacer(unittest.TestCase):
+    def test_replace_single_reference(self):
+        paragraph_string = """<p>Schedule 36 to the <ref uk:canonical="jam">FA 2004</ref>.<CamelCase/></p>"""
+        paragraph_replacements = (
+            {
+                "detected_ref": "the 2004 Act",
+                "ref_para": 100,
+                "ref_position": 487,
+                "ref_tag": '<ref uk:canonical="jam">the 2004 Act</ref>',
+            },
+        )
+        replacement_paragraph = str(
+            create_replacement_paragraph(paragraph_string, paragraph_replacements)
+        )
+        assert "<CamelCase/>" in replacement_paragraph
+        assert "uk:canonical" in replacement_paragraph
+
     def test_replace_references_by_paragraph(self):
         """
         Given some file_data soup and references with ref_tag and positional info
@@ -56,7 +75,6 @@ class TestSecondStageReplacer(unittest.TestCase):
         expected_file_path = f"{FIXTURE_DIR}/ewhc-ch-2023-257_enriched_stage_2.xml"
         with open(expected_file_path, "r", encoding="utf-8") as expected_file:
             expected_enriched_content = expected_file.read()
-
         assert_equal_xml(expected_enriched_content, enriched_content)
 
 

--- a/src/tests/replacer_tests/test_second_stage_replacer.py
+++ b/src/tests/replacer_tests/test_second_stage_replacer.py
@@ -16,6 +16,11 @@ FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures"
 
 class TestSecondStageReplacer(unittest.TestCase):
     def test_replace_single_reference(self):
+        """This tests that when a reference is replaced, it doesn't:
+        * mangle the namespaces
+        * flatten tags to lowercase
+
+        It doesn't test whether the replacement actually works."""
         paragraph_string = """<p>Schedule 36 to the <ref uk:canonical="jam">FA 2004</ref>.<CamelCase/></p>"""
         paragraph_replacements = (
             {
@@ -28,8 +33,11 @@ class TestSecondStageReplacer(unittest.TestCase):
         replacement_paragraph = str(
             create_replacement_paragraph(paragraph_string, paragraph_replacements)
         )
-        assert "<CamelCase/>" in replacement_paragraph
-        assert "uk:canonical" in replacement_paragraph
+
+        assert (
+            replacement_paragraph
+            == '<p>Schedule 36 to the <ref uk:canonical="jam">FA 2004</ref>.<CamelCase/></p>'
+        )
 
     def test_replace_references_by_paragraph(self):
         """

--- a/src/tests/replacer_tests/test_second_stage_replacer.py
+++ b/src/tests/replacer_tests/test_second_stage_replacer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 
 from replacer.second_stage_replacer import replace_references_by_paragraph
+from utils.tests.compare_xml import assert_equal_xml
 
 FIXTURE_DIR = Path(__file__).parent.parent.resolve() / "fixtures"
 
@@ -56,7 +57,7 @@ class TestSecondStageReplacer(unittest.TestCase):
         with open(expected_file_path, "r", encoding="utf-8") as expected_file:
             expected_enriched_content = expected_file.read()
 
-        assert enriched_content.strip() == expected_enriched_content.strip()
+        assert_equal_xml(expected_enriched_content, enriched_content)
 
 
 if __name__ == "__main__":

--- a/src/utils/compare_xml.py
+++ b/src/utils/compare_xml.py
@@ -1,7 +1,9 @@
+from typing import Union
+
 import lxml.etree
 
 
-def canonical_xml(xml_bytes):
+def canonical_xml(xml_bytes: bytes) -> bytes:
     """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
     val = (
         lxml.etree.tostring(lxml.etree.fromstring(xml_bytes), method="c14n2")
@@ -11,7 +13,7 @@ def canonical_xml(xml_bytes):
     return val
 
 
-def assert_equal_xml(a, b):
+def assert_equal_xml(a: Union[str | bytes], b: Union[str | bytes]) -> None:
     """Are the two inputs the same string when canonicalised? If not, display the first difference."""
     if isinstance(a, str):
         a = a.encode("utf-8")
@@ -27,5 +29,5 @@ def assert_equal_xml(a, b):
                 break
         width = 180
         raise AssertionError(
-            f"xml mismatch at {i}\nbefore: {canon_a[i-width:i]}\n first: {canon_a[i:i+width]}\nsecond: {canon_b[i:i+width]}"
+            f"xml mismatch at {i}\nbefore: {canon_a[i-width:i]!r}\n first: {canon_a[i:i+width]!r}\nsecond: {canon_b[i:i+width]!r}"
         )

--- a/src/utils/tests/compare_xml.py
+++ b/src/utils/tests/compare_xml.py
@@ -12,7 +12,7 @@ def canonical_xml(xml_bytes):
 
 
 def assert_equal_xml(a, b):
-    width = 180
+    """Are the two inputs the same string when canonicalised? If not, display the first difference."""
     if isinstance(a, str):
         a = a.encode("utf-8")
     canon_a = canonical_xml(a)
@@ -20,10 +20,12 @@ def assert_equal_xml(a, b):
     if isinstance(b, str):
         b = b.encode("utf-8")
     canon_b = canonical_xml(b)
+
     if canon_a != canon_b:
         for i, (char_a, char_b) in enumerate(zip(canon_a, canon_b)):
             if char_a != char_b:
                 break
+        width = 180
         raise AssertionError(
             f"xml mismatch at {i}\nbefore: {canon_a[i-width:i]}\n first: {canon_a[i:i+width]}\nsecond: {canon_b[i:i+width]}"
         )

--- a/src/utils/tests/compare_xml.py
+++ b/src/utils/tests/compare_xml.py
@@ -1,0 +1,29 @@
+import lxml.etree
+
+
+def canonical_xml(xml_bytes):
+    """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
+    val = (
+        lxml.etree.tostring(lxml.etree.fromstring(xml_bytes), method="c14n2")
+        .replace(b"\n", b"")
+        .replace(b" ", b"")
+    )
+    return val
+
+
+def assert_equal_xml(a, b):
+    width = 180
+    if isinstance(a, str):
+        a = a.encode("utf-8")
+    canon_a = canonical_xml(a)
+
+    if isinstance(b, str):
+        b = b.encode("utf-8")
+    canon_b = canonical_xml(b)
+    if canon_a != canon_b:
+        for i, (char_a, char_b) in enumerate(zip(canon_a, canon_b)):
+            if char_a != char_b:
+                break
+        raise AssertionError(
+            f"xml mismatch at {i}\nbefore: {canon_a[i-width:i]}\n first: {canon_a[i:i+width]}\nsecond: {canon_b[i:i+width]}"
+        )

--- a/src/utils/tests/test_proper_xml.py
+++ b/src/utils/tests/test_proper_xml.py
@@ -1,5 +1,5 @@
+from utils.compare_xml import assert_equal_xml
 from utils.proper_xml import create_tag_string
-from utils.tests.compare_xml import assert_equal_xml
 
 
 def test_simple_tag():

--- a/src/utils/tests/test_proper_xml.py
+++ b/src/utils/tests/test_proper_xml.py
@@ -1,26 +1,5 @@
-import lxml.etree
-
 from utils.proper_xml import create_tag_string
-
-
-def canonical_xml(xml_bytes):
-    """with thanks to https://stackoverflow.com/questions/52422385/python-3-xml-canonicalization"""
-    val = (
-        lxml.etree.tostring(lxml.etree.fromstring(xml_bytes), method="c14n2")
-        .replace(b"\n", b"")
-        .replace(b" ", b"")
-    )
-    return val
-
-
-def assert_equal_xml(a, b):
-    if isinstance(a, str):
-        a = a.encode("utf-8")
-
-    if isinstance(b, str):
-        b = b.encode("utf-8")
-
-    assert canonical_xml(a) == canonical_xml(b)
+from utils.tests.compare_xml import assert_equal_xml
 
 
 def test_simple_tag():


### PR DESCRIPTION
When you initialise BeautifulSoup, you can provide a parser argument. This defaults to HTML, but the rest of Enrichment provides an argument of `"xml"`, which uses Python's default XML parser. In this case, however, the argument was "lxml", which sounds like it should use `lxml.etree`, but it doesn't. Instead it uses `lxml.html`, which converts all tags to lowercase. Unfortunately, XML's tags are case sensitive and this causes explosions with some of our case-sensitive tags such as `authorialNote`.

However, when we remove the `l`, we hit another problem. BeautifulSoup is a forgiving parser, sees that there are no namespaces defined and just throws them away. We wrap the tag in another tag with a defined `uk:` namespace, which BeautifulSoup then pulls just the paragraph from.