### PR TITLE
Add thorough type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,7 @@ repos:
             types-lxml,
             types-beautifulsoup4,
             "boto3-stubs[essential, secretsmanager]",
+            aws_lambda_powertools,
           ]
         exclude: tests/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,6 @@ repos:
             "boto3-stubs[essential, secretsmanager]",
             aws_lambda_powertools,
           ]
-        exclude: tests/
 
   # Check the tests in regular mode
   # - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy-src
-        args: [--explicit-package-bases, --strict]
+        args: [--explicit-package-bases]
         additional_dependencies:
           [
             types-mock,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,8 @@ repos:
     rev: v1.8.0 # Use the sha / tag you want to point at
     hooks:
       - id: mypy
-        args: [--explicit-package-bases]
-        additional_dependencies: [types-mock, types-requests, types-lxml]
+        args: [--explicit-package-bases, --strict]
+        additional_dependencies: [types-mock, types-requests, types-lxml, types-beautifulsoup4]
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,14 @@ repos:
       - id: mypy
         name: mypy-src
         args: [--explicit-package-bases, --strict]
-        additional_dependencies: [types-mock, types-requests, types-lxml, types-beautifulsoup4]
+        additional_dependencies:
+          [
+            types-mock,
+            types-requests,
+            types-lxml,
+            types-beautifulsoup4,
+            "boto3-stubs[essential, secretsmanager]",
+          ]
         exclude: tests/
 
   # Check the tests in regular mode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,19 @@ repos:
     rev: v1.8.0 # Use the sha / tag you want to point at
     hooks:
       - id: mypy
+        name: mypy-src
         args: [--explicit-package-bases, --strict]
         additional_dependencies: [types-mock, types-requests, types-lxml, types-beautifulsoup4]
+        exclude: tests/
+
+  # Check the tests in regular mode
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.7.1
+  #   hooks:
+  #     - id: mypy
+  #       name: mypy-tests
+  #       additional_dependencies: [types-mock, types-requests, types-lxml, types-beautifulsoup4]
+  #       files: tests/
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: mypy
         args: [--explicit-package-bases]
-        additional_dependencies: [types-mock, types-requests]
+        additional_dependencies: [types-mock, types-requests, types-lxml]
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/src/abbreviation_extraction/abbreviations_matcher.py
+++ b/src/abbreviation_extraction/abbreviations_matcher.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from spacy.language import Language
 
 from abbreviation_extraction.abbreviations import AbbreviationDetector
+from utils.types import NLPModel
 
 abb = namedtuple("abb", "abb_match longform")
 
@@ -40,7 +41,7 @@ def chunking_mechanism(docobj, n, start, end):
     return judgment_chunks
 
 
-def abb_pipeline(judgment_content_text, nlp):
+def abb_pipeline(judgment_content_text: str, nlp: NLPModel) -> list[abb]:
     """
     Main controller of the abbreviation detection pipeline.
     :param judgment_content_text: judgment content
@@ -53,7 +54,7 @@ def abb_pipeline(judgment_content_text, nlp):
 
     # init the class - stateful pipeline component
     @Language.factory("abbreviation_detector")
-    def create_abbreviation_detector(nlp, name: str):
+    def create_abbreviation_detector(nlp: NLPModel, name: str) -> AbbreviationDetector:
         return AbbreviationDetector(nlp)
 
     nlp.add_pipe("abbreviation_detector", last=True)

--- a/src/abbreviation_extraction/requirements.txt
+++ b/src/abbreviation_extraction/requirements.txt
@@ -1,2 +1,3 @@
 spacy==3.7.2
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
+aws_lambda_powertools==2.30.2

--- a/src/caselaw_extraction/requirements.txt
+++ b/src/caselaw_extraction/requirements.txt
@@ -8,3 +8,4 @@ psycopg2-binary==2.9.9
 beautifulsoup4==4.12.2
 lxml==4.9.3
 sqlalchemy==2.0.23
+aws_lambda_powertools==2.30.2

--- a/src/database/db_connection.py
+++ b/src/database/db_connection.py
@@ -1,11 +1,16 @@
 """ Handles the database connection """
 
 
+from typing import Any
+
 import pandas as pd
 import psycopg2
+from sqlalchemy import Connection
 
 
-def create_connection(db, user, password, host, port) -> psycopg2.extensions.connection:
+def create_connection(
+    db: str, user: str, password: str, host: str, port: str
+) -> psycopg2.extensions.connection:
     """
     Connect to the PostgreSQL database server
     :param db
@@ -28,7 +33,7 @@ def create_connection(db, user, password, host, port) -> psycopg2.extensions.con
         raise
 
 
-def get_manifest_row(conn, rule_id):
+def get_manifest_row(conn: Connection, rule_id: str) -> pd.DataFrame:
     """
     Select all fields/rows from manifest that match the rule id
     :param conn: database connection created with create_connection()
@@ -41,7 +46,9 @@ def get_manifest_row(conn, rule_id):
     return matched_rule
 
 
-def get_matched_rule(conn, rule_id):
+def get_matched_rule(
+    conn: Connection, rule_id: str
+) -> tuple[Any, Any, bool, Any, Any, Any]:
     """
     Uses database connection to select fields/rows of interest from manifest that match the rule id
     :param conn: database connection, required
@@ -58,7 +65,7 @@ def get_matched_rule(conn, rule_id):
     return family, URItemplate, is_neutral, is_canonical, citation_type, canonical_form
 
 
-def get_legtitles(conn):
+def get_legtitles(conn: Connection) -> pd.DataFrame:
     """
     Retrieves legislation titles from legislation lookup table
     :param conn: database connection, required
@@ -70,7 +77,7 @@ def get_legtitles(conn):
     return leg_titles
 
 
-def get_hrefs(conn, title):
+def get_hrefs(conn: Connection, title: str):
     """
     Retrieves link to legislation title
     :param conn: database connection, required
@@ -82,7 +89,7 @@ def get_hrefs(conn, title):
     return test.ref.values[0]
 
 
-def get_canonical_leg(conn, title):
+def get_canonical_leg(conn, title: str):
     """
     Retrieves canonical form of legislation title
     :param conn: database connection, required
@@ -98,7 +105,7 @@ def get_canonical_leg(conn, title):
     return canonical_leg.citation.values[0]
 
 
-def close_connection(conn):
+def close_connection(conn: Connection) -> None:
     """
     Closes the Database connection
     :param conn: database connection to be closed

--- a/src/database/requirements.txt
+++ b/src/database/requirements.txt
@@ -1,2 +1,3 @@
 pandas==2.1.4
 psycopg2==2.9.9
+sqlalchemy==2.0.23

--- a/src/lambdas/db_backup/index.py
+++ b/src/lambdas/db_backup/index.py
@@ -1,10 +1,16 @@
 from datetime import datetime
 
 import boto3
+from aws_lambda_powertools.utilities.data_classes import (
+    EventBridgeEvent,
+    event_source,
+)
+from aws_lambda_powertools.utilities.typing import LambdaContext
 from botocore.exceptions import ClientError
 
 
-def lambda_handler(event, context):
+@event_source(data_class=EventBridgeEvent)
+def lambda_handler(event: EventBridgeEvent, context: LambdaContext) -> None:
     # Create RDS and S3 clients
     rds = boto3.client("rds")
     db = event["db-name"]

--- a/src/lambdas/db_backup/requirements.txt
+++ b/src/lambdas/db_backup/requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.34.11
 botocore==1.34.11
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -5,6 +5,9 @@ import logging
 import urllib.parse
 
 import boto3
+from aws_lambda_powertools.utilities.data_classes import S3Event, event_source
+from aws_lambda_powertools.utilities.data_classes.s3_event import S3EventRecord
+from aws_lambda_powertools.utilities.typing import LambdaContext
 from bs4 import BeautifulSoup
 
 from legislation_provisions_extraction.legislation_provisions import (
@@ -50,16 +53,14 @@ def add_timestamp_and_engine_version(file_data):
     return soup
 
 
-def process_event(sqs_rec):
+def process_event(sqs_rec: S3EventRecord) -> None:
     """
     Function to fetch the XML, call the legislation provisions extraction pipeline and upload the enriched XML to the
     destination bucket
     """
     s3_client = boto3.client("s3")
-    source_bucket = sqs_rec["s3"]["bucket"]["name"]
-    source_key = urllib.parse.unquote_plus(
-        sqs_rec["s3"]["object"]["key"], encoding="utf-8"
-    )
+    source_bucket = sqs_rec.s3.bucket.name
+    source_key = urllib.parse.unquote_plus(sqs_rec.s3.get_object.key, encoding="utf-8")
     print("Input bucket name:", source_bucket)
     print("Input S3 key:", source_key)
 
@@ -85,7 +86,8 @@ def process_event(sqs_rec):
 DEST_BUCKET = validate_env_variable("DEST_BUCKET")
 
 
-def handler(event, context):
+@event_source(data_class=S3Event)
+def handler(event: S3Event, context: LambdaContext) -> None:
     """
     Function called by the lambda to run the process event
     """
@@ -93,7 +95,7 @@ def handler(event, context):
     try:
         LOGGER.info("SQS EVENT: %s", event)
 
-        for sqs_rec in event["Records"]:
+        for sqs_rec in event.records:
             # stop the test notification event from breaking the parsing logic
             if "Event" in sqs_rec.keys() and sqs_rec["Event"] == "s3:TestEvent":
                 break

--- a/src/lambdas/determine_oblique_references/index.py
+++ b/src/lambdas/determine_oblique_references/index.py
@@ -12,12 +12,13 @@ from oblique_references.enrich_oblique_references import (
     enrich_oblique_references,
 )
 from utils.environment_helpers import validate_env_variable
+from utils.types import DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 
-def upload_contents(source_key, output_file_content):
+def upload_contents(source_key: str, output_file_content: DocumentAsXMLString) -> None:
     """
     Upload enriched file to S3 bucket
     """
@@ -40,7 +41,7 @@ def process_event(sqs_rec: S3EventRecord) -> None:
     print("Input bucket name:", source_bucket)
     print("Input S3 key:", source_key)
 
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]
         .read()
         .decode("utf-8")

--- a/src/lambdas/determine_oblique_references/index.py
+++ b/src/lambdas/determine_oblique_references/index.py
@@ -4,6 +4,9 @@ import logging
 import urllib.parse
 
 import boto3
+from aws_lambda_powertools.utilities.data_classes import S3Event, event_source
+from aws_lambda_powertools.utilities.data_classes.s3_event import S3EventRecord
+from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from oblique_references.enrich_oblique_references import (
     enrich_oblique_references,
@@ -26,16 +29,14 @@ def upload_contents(source_key, output_file_content):
     object.put(Body=output_file_content)
 
 
-def process_event(sqs_rec):
+def process_event(sqs_rec: S3EventRecord) -> None:
     """
     Function to fetch the XML, call the oblique references pipeline and upload the enriched XML to the
     destination bucket
     """
     s3_client = boto3.client("s3")
-    source_bucket = sqs_rec["s3"]["bucket"]["name"]
-    source_key = urllib.parse.unquote_plus(
-        sqs_rec["s3"]["object"]["key"], encoding="utf-8"
-    )
+    source_bucket = sqs_rec.s3.bucket.name
+    source_key = urllib.parse.unquote_plus(sqs_rec.s3.get_object.key, encoding="utf-8")
     print("Input bucket name:", source_bucket)
     print("Input S3 key:", source_key)
 
@@ -50,7 +51,8 @@ def process_event(sqs_rec):
     upload_contents(source_key, enriched_content)
 
 
-def handler(event, context):
+@event_source(data_class=S3Event)
+def handler(event: S3Event, context: LambdaContext) -> None:
     """
     Function called by the lambda to run the process event
     """
@@ -58,7 +60,7 @@ def handler(event, context):
     try:
         LOGGER.info("SQS EVENT: %s", event)
 
-        for sqs_rec in event["Records"]:
+        for sqs_rec in event.records:
             # stop the test notification event from breaking the parsing logic
             if "Event" in sqs_rec.keys() and sqs_rec["Event"] == "s3:TestEvent":
                 break

--- a/src/lambdas/determine_replacements_abbreviations/index.py
+++ b/src/lambdas/determine_replacements_abbreviations/index.py
@@ -5,6 +5,9 @@ import logging
 
 import boto3
 import spacy
+from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
+from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from utils.environment_helpers import validate_env_variable
 
@@ -13,7 +16,7 @@ LOGGER.setLevel(logging.INFO)
 
 
 # isolating processing from event unpacking for portability and testing
-def process_event(sqs_rec):
+def process_event(sqs_rec: SQSRecord) -> None:
     """
     Function to fetch the XML, call the replacements abbreviations pipeline and upload the enriched XML to the
     destination bucket
@@ -135,7 +138,8 @@ DEST_QUEUE = validate_env_variable("DEST_QUEUE_NAME")
 REPLACEMENTS_BUCKET = validate_env_variable("REPLACEMENTS_BUCKET")
 
 
-def handler(event, context):
+@event_source(data_class=SQSEvent)
+def handler(event: SQSEvent, context: LambdaContext) -> None:
     """
     Function called by the lambda to run the process event
     """
@@ -144,7 +148,7 @@ def handler(event, context):
     try:
         LOGGER.info("SQS EVENT: %s", event)
 
-        for sqs_rec in event["Records"]:
+        for sqs_rec in event.records:
             # stop the test notification event from breaking the parsing logic
             if "Event" in sqs_rec.keys() and sqs_rec["Event"] == "s3:TestEvent":
                 break

--- a/src/lambdas/determine_replacements_abbreviations/index.py
+++ b/src/lambdas/determine_replacements_abbreviations/index.py
@@ -8,6 +8,7 @@ import spacy
 from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from mypy_boto3_sqs.type_defs import MessageAttributeValueQueueTypeDef
 
 from utils.environment_helpers import validate_env_variable
 from utils.types import DocumentAsXMLString
@@ -126,7 +127,7 @@ def push_contents(uploaded_bucket, uploaded_key):
 
     # Create a new message
     message = {"replacements": uploaded_key}
-    msg_attributes = {
+    msg_attributes: dict[str, MessageAttributeValueQueueTypeDef] = {
         "source_key": {"DataType": "String", "StringValue": uploaded_key},
         "source_bucket": {"DataType": "String", "StringValue": uploaded_bucket},
     }

--- a/src/lambdas/determine_replacements_abbreviations/index.py
+++ b/src/lambdas/determine_replacements_abbreviations/index.py
@@ -10,6 +10,7 @@ from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from utils.environment_helpers import validate_env_variable
+from utils.types import DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -36,7 +37,7 @@ def process_event(sqs_rec: SQSRecord) -> None:
     LOGGER.debug("Input S3 key:%s", source_key)
 
     # fetch the judgement contents
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]
         .read()
         .decode("utf-8")

--- a/src/lambdas/determine_replacements_caselaw/index.py
+++ b/src/lambdas/determine_replacements_caselaw/index.py
@@ -13,6 +13,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from database import db_connection
 from utils.environment_helpers import validate_env_variable
 from utils.initialise_db import init_db_connection
+from utils.types import DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -31,7 +32,7 @@ def process_event(sqs_rec: S3EventRecord) -> None:
     LOGGER.info("Input S3 key:%s", source_key)
 
     # fetch the judgement contents
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]
         .read()
         .decode("utf-8")

--- a/src/lambdas/determine_replacements_caselaw/index.py
+++ b/src/lambdas/determine_replacements_caselaw/index.py
@@ -9,6 +9,7 @@ import spacy
 from aws_lambda_powertools.utilities.data_classes import S3Event, event_source
 from aws_lambda_powertools.utilities.data_classes.s3_event import S3EventRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from mypy_boto3_sqs.type_defs import MessageAttributeValueQueueTypeDef
 
 from database import db_connection
 from utils.environment_helpers import validate_env_variable
@@ -172,7 +173,7 @@ def push_contents(uploaded_bucket, uploaded_key):
 
     # Create a new message
     message = {"replacements": uploaded_key}
-    msg_attributes = {
+    msg_attributes: dict[str, MessageAttributeValueQueueTypeDef] = {
         "source_key": {"DataType": "String", "StringValue": uploaded_key},
         "source_bucket": {"DataType": "String", "StringValue": uploaded_bucket},
     }

--- a/src/lambdas/determine_replacements_caselaw/index.py
+++ b/src/lambdas/determine_replacements_caselaw/index.py
@@ -72,7 +72,9 @@ def write_replacements_file(replacement_list):
     return tuple_file
 
 
-def upload_replacements(replacements_bucket, replacements_key, replacements):
+def upload_replacements(
+    replacements_bucket: str, replacements_key: str, replacements: str
+) -> str:
     """
     Uploads replacements to S3 bucket
     """

--- a/src/lambdas/determine_replacements_legislation/index.py
+++ b/src/lambdas/determine_replacements_legislation/index.py
@@ -8,6 +8,7 @@ import spacy
 from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from mypy_boto3_sqs.type_defs import MessageAttributeValueQueueTypeDef
 
 from database import db_connection
 from utils.environment_helpers import validate_env_variable
@@ -181,7 +182,7 @@ def push_contents(uploaded_bucket, uploaded_key):
 
     # Create a new message
     message = {"replacements": uploaded_key}
-    msg_attributes = {
+    msg_attributes: dict[str, MessageAttributeValueQueueTypeDef] = {
         "source_key": {"DataType": "String", "StringValue": uploaded_key},
         "source_bucket": {"DataType": "String", "StringValue": uploaded_bucket},
     }

--- a/src/lambdas/determine_replacements_legislation/index.py
+++ b/src/lambdas/determine_replacements_legislation/index.py
@@ -12,6 +12,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from database import db_connection
 from utils.environment_helpers import validate_env_variable
 from utils.initialise_db import init_db_connection
+from utils.types import DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -39,7 +40,7 @@ def process_event(sqs_rec: SQSRecord) -> None:
     LOGGER.info("Input S3 key:%s", source_key)
 
     # fetch the judgement contents
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]
         .read()
         .decode("utf-8")

--- a/src/lambdas/determine_replacements_legislation/index.py
+++ b/src/lambdas/determine_replacements_legislation/index.py
@@ -5,6 +5,9 @@ import logging
 
 import boto3
 import spacy
+from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
+from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from database import db_connection
 from utils.environment_helpers import validate_env_variable
@@ -15,14 +18,14 @@ LOGGER.setLevel(logging.INFO)
 
 
 # isolating processing from event unpacking for portability and testing
-def process_event(sqs_rec):
+def process_event(sqs_rec: SQSRecord) -> None:
     """
     Function to fetch the XML, call the legislation replacements pipeline and upload the enriched XML to the
     destination bucket
     """
     s3_client = boto3.client("s3")
 
-    message = json.loads(sqs_rec["body"])
+    message = json.loads(sqs_rec.body)
     LOGGER.info("EVENT: %s", message)
     msg_attributes = sqs_rec["messageAttributes"]
     replacements = message["replacements"]
@@ -191,7 +194,8 @@ REPLACEMENTS_BUCKET = validate_env_variable("REPLACEMENTS_BUCKET")
 ENRICHMENT_BUCKET = validate_env_variable("ENRICHMENT_BUCKET")
 
 
-def handler(event, context):
+@event_source(data_class=SQSEvent)
+def handler(event: SQSEvent, context: LambdaContext) -> None:
     """
     Function called by the lambda to run the process event
     """
@@ -200,7 +204,7 @@ def handler(event, context):
     try:
         LOGGER.info("SQS EVENT: %s", event)
 
-        for sqs_rec in event["Records"]:
+        for sqs_rec in event.records:
             # stop the test notification event from breaking the parsing logic
             if "Event" in sqs_rec.keys() and sqs_rec["Event"] == "s3:TestEvent":
                 break

--- a/src/lambdas/determine_replacements_legislation/index.py
+++ b/src/lambdas/determine_replacements_legislation/index.py
@@ -13,7 +13,7 @@ from mypy_boto3_sqs.type_defs import MessageAttributeValueQueueTypeDef
 from database import db_connection
 from utils.environment_helpers import validate_env_variable
 from utils.initialise_db import init_db_connection
-from utils.types import DocumentAsXMLString
+from utils.types import DocumentAsXMLString, NLPModel
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -106,7 +106,9 @@ def write_replacements_file(replacement_list):
     return tuple_file
 
 
-def upload_replacements(replacements_bucket, replacements_key, replacements):
+def upload_replacements(
+    replacements_bucket: str, replacements_key: str, replacements: str
+) -> str:
     """
     Uploads replacements to S3 bucket
     """
@@ -119,7 +121,7 @@ def upload_replacements(replacements_bucket, replacements_key, replacements):
     return object.key
 
 
-def init_NLP():
+def init_NLP() -> NLPModel:
     """
     Load spacy model
     """
@@ -130,7 +132,7 @@ def init_NLP():
     return nlp
 
 
-def close_connection(db_conn):
+def close_connection(db_conn) -> None:
     """
     Close the database connection
     """

--- a/src/lambdas/extract_judgement_contents/index.py
+++ b/src/lambdas/extract_judgement_contents/index.py
@@ -11,6 +11,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from utils.environment_helpers import validate_env_variable
 from utils.helper import parse_file
+from utils.types import DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -26,7 +27,7 @@ def process_event(sqs_rec: S3EventRecord):
     print("Input bucket name:", source_bucket)
     print("Input S3 key:", source_key)
 
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]
         .read()
         .decode("utf-8")
@@ -37,12 +38,11 @@ def process_event(sqs_rec: S3EventRecord):
     upload_contents(source_key, text_content)
 
 
-def extract_text_content(file_content):
+def extract_text_content(file_content: DocumentAsXMLString) -> str:
     """
     Extract text from the content elements of the XML file
     """
-    file_content = parse_file(file_content)
-    return file_content
+    return parse_file(file_content)
 
 
 def upload_contents(source_key, text_content):

--- a/src/lambdas/extract_judgement_contents/requirements.txt
+++ b/src/lambdas/extract_judgement_contents/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.12.2
 lxml==4.9.3
 pandas==2.1.4
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/fetch_xml/index.py
+++ b/src/lambdas/fetch_xml/index.py
@@ -8,6 +8,7 @@ from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from utils.environment_helpers import validate_env_variable
+from utils.types import APIEndpointBaseURL
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -18,7 +19,9 @@ LOGGER.setLevel(logging.INFO)
 ############################################
 
 
-def fetch_judgment_urllib(api_endpoint, query, username, pw):
+def fetch_judgment_urllib(
+    api_endpoint: APIEndpointBaseURL, query: str, username: str, pw: str
+) -> str:
     """
     Fetch the judgment from the National Archives
     """
@@ -31,7 +34,9 @@ def fetch_judgment_urllib(api_endpoint, query, username, pw):
     return r.data.decode()
 
 
-def lock_judgment_urllib(api_endpoint, query, username, pw):
+def lock_judgment_urllib(
+    api_endpoint: APIEndpointBaseURL, query: str, username: str, pw: str
+) -> None:
     """
     Lock the judgment for editing
     """
@@ -43,7 +48,9 @@ def lock_judgment_urllib(api_endpoint, query, username, pw):
     # return r.data.decode()
 
 
-def check_lock_judgment_urllib(api_endpoint, query, username, pw):
+def check_lock_judgment_urllib(
+    api_endpoint: APIEndpointBaseURL, query: str, username: str, pw: str
+) -> None:
     """
     Check whether the judgment is locked
     """
@@ -87,7 +94,7 @@ def upload_contents(source_key, xml_content):
     object.put(Body=xml_content)
 
 
-def process_event(sqs_rec: SQSRecord, api_endpoint) -> None:
+def process_event(sqs_rec: SQSRecord, api_endpoint: APIEndpointBaseURL) -> None:
     """
     Function to check the status of the judgment, fetch the judgment if it is published, lock the judgment for editing
     and upload to destination S3 bucket
@@ -130,9 +137,14 @@ def handler(event: SQSEvent, context: LambdaContext) -> None:
     LOGGER.info(ENVIRONMENT)
 
     if ENVIRONMENT == "staging":
-        api_endpoint = "https://api.staging.caselaw.nationalarchives.gov.uk/"
+        api_endpoint = APIEndpointBaseURL(
+            "https://api.staging.caselaw.nationalarchives.gov.uk/"
+        )
+
     else:
-        api_endpoint = "https://api.caselaw.nationalarchives.gov.uk/"
+        api_endpoint = APIEndpointBaseURL(
+            "https://api.caselaw.nationalarchives.gov.uk/"
+        )
 
     try:
         LOGGER.info("SQS EVENT: %s", event)

--- a/src/lambdas/fetch_xml/index.py
+++ b/src/lambdas/fetch_xml/index.py
@@ -8,7 +8,7 @@ from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from utils.environment_helpers import validate_env_variable
-from utils.types import APIEndpointBaseURL
+from utils.types import APIEndpointBaseURL, DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -21,7 +21,7 @@ LOGGER.setLevel(logging.INFO)
 
 def fetch_judgment_urllib(
     api_endpoint: APIEndpointBaseURL, query: str, username: str, pw: str
-) -> str:
+) -> DocumentAsXMLString:
     """
     Fetch the judgment from the National Archives
     """
@@ -31,7 +31,7 @@ def fetch_judgment_urllib(
     r = http.request("GET", url, headers=headers)
     print("Fetch judgment status:", r.status)
     print("Fetch judgment data:", r.data)
-    return r.data.decode()
+    return DocumentAsXMLString(r.data.decode())
 
 
 def lock_judgment_urllib(
@@ -83,7 +83,7 @@ def read_message(message):
     return status, query
 
 
-def upload_contents(source_key, xml_content):
+def upload_contents(source_key: str, xml_content: DocumentAsXMLString) -> None:
     """
     Upload judgment to destination S3 bucket
     """

--- a/src/lambdas/fetch_xml/index.py
+++ b/src/lambdas/fetch_xml/index.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Any
 
 import boto3
 import urllib3
@@ -68,11 +69,11 @@ def check_lock_judgment_urllib(
 ############################################
 
 
-def read_message(message):
+def read_message(message_dict: dict[Any, Any]) -> tuple[str, str]:
     """
     Return the status and URI of the judgment
     """
-    json_body = json.dumps(message)
+    json_body = json.dumps(message_dict)
     json_message = json.loads(json_body)
     message = json_message["Message"]
     message_read = json.loads(message)

--- a/src/lambdas/fetch_xml/requirements.txt
+++ b/src/lambdas/fetch_xml/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.31.0
 boto3==1.34.11
 botocore==1.34.11
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/make_replacements/index.py
+++ b/src/lambdas/make_replacements/index.py
@@ -7,23 +7,10 @@ import os
 import boto3
 
 from replacer.make_replacments import make_post_header_replacements
+from utils.environment_helpers import validate_env_variable
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 def upload_contents(source_key, text_content):

--- a/src/lambdas/make_replacements/index.py
+++ b/src/lambdas/make_replacements/index.py
@@ -11,12 +11,13 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from replacer.make_replacments import make_post_header_replacements
 from utils.environment_helpers import validate_env_variable
+from utils.types import DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
 
 
-def upload_contents(source_key, text_content):
+def upload_contents(source_key: str, text_content: DocumentAsXMLString) -> None:
     """
     Upload judgment to destination S3 bucket
     """
@@ -55,7 +56,7 @@ def process_event(sqs_rec: SQSRecord) -> None:
     LOGGER.info("Filename")
     LOGGER.info(filename)
 
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=SOURCE_BUCKET, Key=filename)["Body"]
         .read()
         .decode("utf-8")

--- a/src/lambdas/make_replacements/requirements.txt
+++ b/src/lambdas/make_replacements/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.3
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -34,19 +34,6 @@ def fetch_judgment_urllib(api_endpoint: APIEndpointBaseURL, query, username, pw)
     return r.data.decode()
 
 
-def patch_judgment(api_endpoint: APIEndpointBaseURL, query, data, username, pw):
-    """
-    Apply enrichments to the judgment
-    """
-    http = urllib3.PoolManager()
-    url = f"{api_endpoint}judgment/{query}"
-    headers = urllib3.make_headers(basic_auth=username + ":" + pw)
-    r = http.request("PATCH", url, headers=headers, fields=data)
-    print(r.status)
-    print(r.data)
-    return r.data.decode()
-
-
 def release_lock(api_endpoint: APIEndpointBaseURL, query, username, pw):
     """
     Unlock the judgment after editing

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -10,7 +10,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from requests.auth import HTTPBasicAuth
 
 from utils.environment_helpers import validate_env_variable
-from utils.types import APIEndpointBaseURL
+from utils.types import APIEndpointBaseURL, DocumentAsXMLString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -1,28 +1,15 @@
 import json
 import logging
-import os
 
 import boto3
 import requests
 import urllib3
 from requests.auth import HTTPBasicAuth
 
+from utils.environment_helpers import validate_env_variable
+
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-
-
-def validate_env_variable(env_var_name):
-    LOGGER.debug(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 ############################################

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -10,6 +10,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from requests.auth import HTTPBasicAuth
 
 from utils.environment_helpers import validate_env_variable
+from utils.types import APIEndpointBaseURL
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
@@ -20,7 +21,7 @@ LOGGER.setLevel(logging.INFO)
 ############################################
 
 
-def fetch_judgment_urllib(api_endpoint, query, username, pw):
+def fetch_judgment_urllib(api_endpoint: APIEndpointBaseURL, query, username, pw):
     """
     Fetch the judgment from the National Archives
     """
@@ -33,7 +34,7 @@ def fetch_judgment_urllib(api_endpoint, query, username, pw):
     return r.data.decode()
 
 
-def patch_judgment(api_endpoint, query, data, username, pw):
+def patch_judgment(api_endpoint: APIEndpointBaseURL, query, data, username, pw):
     """
     Apply enrichments to the judgment
     """
@@ -46,7 +47,7 @@ def patch_judgment(api_endpoint, query, data, username, pw):
     return r.data.decode()
 
 
-def release_lock(api_endpoint, query, username, pw):
+def release_lock(api_endpoint: APIEndpointBaseURL, query, username, pw):
     """
     Unlock the judgment after editing
     """
@@ -59,7 +60,7 @@ def release_lock(api_endpoint, query, username, pw):
     return r.data.decode()
 
 
-def patch_judgment_request(api_endpoint, query, data, username, pw):
+def patch_judgment_request(api_endpoint: APIEndpointBaseURL, query, data, username, pw):
     """
     Apply enrichments to the judgment
     """
@@ -94,11 +95,15 @@ def process_event(sqs_rec: SQSRecord) -> None:
     LOGGER.info(validated_file)
 
     if ENVIRONMENT == "staging":
-        api_endpoint = "https://api.staging.caselaw.nationalarchives.gov.uk/"
+        api_endpoint = APIEndpointBaseURL(
+            "https://api.staging.caselaw.nationalarchives.gov.uk/"
+        )
     else:
-        api_endpoint = "https://api.caselaw.nationalarchives.gov.uk/"
+        api_endpoint = APIEndpointBaseURL(
+            "https://api.caselaw.nationalarchives.gov.uk/"
+        )
 
-    file_content = (
+    file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"]
         .read()
         .decode("utf-8")

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -21,7 +21,9 @@ LOGGER.setLevel(logging.INFO)
 ############################################
 
 
-def fetch_judgment_urllib(api_endpoint: APIEndpointBaseURL, query, username, pw):
+def fetch_judgment_urllib(
+    api_endpoint: APIEndpointBaseURL, query: str, username: str, pw: str
+) -> DocumentAsXMLString:
     """
     Fetch the judgment from the National Archives
     """
@@ -31,10 +33,12 @@ def fetch_judgment_urllib(api_endpoint: APIEndpointBaseURL, query, username, pw)
     r = http.request("GET", url, headers=headers)
     print(r.status)
     print(r.data)
-    return r.data.decode()
+    return DocumentAsXMLString(r.data.decode())
 
 
-def release_lock(api_endpoint: APIEndpointBaseURL, query, username, pw):
+def release_lock(
+    api_endpoint: APIEndpointBaseURL, query: str, username: str, pw: str
+) -> None:
     """
     Unlock the judgment after editing
     """
@@ -44,10 +48,11 @@ def release_lock(api_endpoint: APIEndpointBaseURL, query, username, pw):
     r = http.request("DELETE", url, headers=headers)
     print(r.status)
     print(r.data)
-    return r.data.decode()
 
 
-def patch_judgment_request(api_endpoint: APIEndpointBaseURL, query, data, username, pw):
+def patch_judgment_request(
+    api_endpoint: APIEndpointBaseURL, query: str, data: str, username: str, pw: str
+) -> None:
     """
     Apply enrichments to the judgment
     """

--- a/src/lambdas/push_enriched_xml/requirements.txt
+++ b/src/lambdas/push_enriched_xml/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.31.0
 boto3==1.34.11
 botocore==1.34.11
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/update_legislation_table/index.py
+++ b/src/lambdas/update_legislation_table/index.py
@@ -1,6 +1,11 @@
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
+from aws_lambda_powertools.utilities.data_classes import (
+    EventBridgeEvent,
+    event_source,
+)
+from aws_lambda_powertools.utilities.typing import LambdaContext
 from update_legislation_table.database import remove_duplicates
 from update_legislation_table.fetch_legislation import fetch_legislation
 
@@ -13,7 +18,8 @@ LOGGER.setLevel(logging.INFO)
 LEGISLATION_TABLE_NAME = "ukpga_lookup"
 
 
-def handler(event: Dict, context) -> None:
+@event_source(data_class=EventBridgeEvent)
+def handler(event: EventBridgeEvent, context: LambdaContext) -> None:
     """
     Lambda function handler that updates the legislation table
     """

--- a/src/lambdas/update_legislation_table/requirements.txt
+++ b/src/lambdas/update_legislation_table/requirements.txt
@@ -2,3 +2,4 @@ psycopg2-binary==2.9.9
 pandas==2.1.4
 sqlalchemy==2.0.23
 SPARQLWrapper==2.0.0
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/update_legislation_table/update_legislation_table/database.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/database.py
@@ -5,7 +5,7 @@ This module contains utility functions for working with databases using SQLAlche
 from sqlalchemy import Connection, text
 
 
-def remove_duplicates(db_conn: Connection, table_name: str):
+def remove_duplicates(db_conn: Connection, table_name: str) -> None:
     """
     Removes duplicate rows from the specified table in the database.
     Uses a SQL query to identify duplicate rows based on all columns, except for the

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
@@ -15,7 +15,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from dotenv import load_dotenv
-from update_legislation_table.fetch_legislation import fetch_legislation
+
+from ..fetch_legislation import fetch_legislation
 
 
 @pytest.fixture(scope="module")

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
@@ -42,8 +42,8 @@ def test_fetch_legislation_integration(mock_datetime, set_env_vars) -> None:
     mock_datetime.today.return_value = frozen_date
 
     # WHEN
-    sparql_username = os.environ.get("SPARQL_USERNAME")
-    sparql_password = os.environ.get("SPARQL_PASSWORD")
+    sparql_username = os.environ.get("SPARQL_USERNAME", "")
+    sparql_password = os.environ.get("SPARQL_PASSWORD", "")
 
     days = 16
 

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_remove_duplicates.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_remove_duplicates.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine, text
 from testing.postgresql import Postgresql
-from update_legislation_table.database import remove_duplicates
+
+from ..database import remove_duplicates
 
 
 def test_remove_duplicates():

--- a/src/lambdas/update_rules_processor/index.py
+++ b/src/lambdas/update_rules_processor/index.py
@@ -17,9 +17,9 @@ LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 
-def write_patterns_file(patterns_list):
+def write_patterns_file(patterns_list: str) -> str:
     """
-    Write patterns to seperate lines
+    Write patterns to separate lines
     """
     patterns_file = ""
     for pattern in patterns_list:
@@ -27,7 +27,9 @@ def write_patterns_file(patterns_list):
     return patterns_file
 
 
-def upload_replacements(pattern_bucket, pattern_key, patterns_file):
+def upload_replacements(
+    pattern_bucket: str, pattern_key: str, patterns_file: str
+) -> str:
     """
     Upload replacements to S3 bucket
     """
@@ -38,7 +40,7 @@ def upload_replacements(pattern_bucket, pattern_key, patterns_file):
     return object.key
 
 
-def create_test_jsonl(source_bucket, df):
+def create_test_jsonl(source_bucket: str, df: pd.DataFrame) -> None:
     """
     Create test jsonl of patterns pulled from a csv
     """
@@ -47,7 +49,7 @@ def create_test_jsonl(source_bucket, df):
     upload_replacements(source_bucket, "test_citation_patterns.jsonl", patterns_file)
 
 
-def test_manifest(df, patterns):
+def test_manifest(df: pd.DataFrame, patterns: list[str]) -> None:
     """
     Test for the rules manifest.
     """

--- a/src/lambdas/update_rules_processor/index.py
+++ b/src/lambdas/update_rules_processor/index.py
@@ -8,6 +8,8 @@ from io import StringIO
 import boto3
 import pandas as pd
 import spacy
+from aws_lambda_powertools.utilities.data_classes import S3Event, event_source
+from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from utils.initialise_db import init_db_engine
 
@@ -71,7 +73,8 @@ def test_manifest(df, patterns):
     assert len(MATCHED_IDS) == df.shape[0]
 
 
-def lambda_handler(event, context):
+@event_source(data_class=S3Event)
+def lambda_handler(event: S3Event, context: LambdaContext) -> None:
     """
     Function called by the lambda to update the rules
     """
@@ -79,9 +82,10 @@ def lambda_handler(event, context):
 
     # read CSV file from rules bucket
     s3 = boto3.client("s3")
-    source_bucket = event["Records"][0]["s3"]["bucket"]["name"]
+    event_record = event.record
+    source_bucket = event_record.s3.bucket.name
     source_key = urllib.parse.unquote_plus(
-        event["Records"][0]["s3"]["object"]["key"], encoding="utf-8"
+        event_record.s3.get_object.key, encoding="utf-8"
     )
     print(source_bucket)
     print(source_key)

--- a/src/lambdas/update_rules_processor/requirements.txt
+++ b/src/lambdas/update_rules_processor/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy==2.0.23
 boto3==1.34.11
 spacy==3.7.2
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
+aws_lambda_powertools==2.30.2

--- a/src/lambdas/vlex_upload/index.py
+++ b/src/lambdas/vlex_upload/index.py
@@ -7,22 +7,10 @@ from distutils.util import strtobool
 
 import boto3
 
+from utils.environment_helpers import validate_env_variable
+
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
-
-
-def validate_env_variable(env_var_name):
-    print(f"Getting the value of the environment variable: {env_var_name}")
-
-    try:
-        env_variable = os.environ[env_var_name]
-    except KeyError:
-        raise Exception(f"Please, set environment variable {env_var_name}")
-
-    if not env_variable:
-        raise Exception(f"Please, provide environment variable {env_var_name}")
-
-    return env_variable
 
 
 def process_event(sqs_rec):

--- a/src/lambdas/vlex_upload/index.py
+++ b/src/lambdas/vlex_upload/index.py
@@ -55,7 +55,7 @@ DEST_BUCKET = validate_env_variable("DEST_BUCKET_NAME")
 FORWARD_TO_VLEX_ENABLED = strtobool(validate_env_variable("FORWARD_TO_VLEX_ENABLED"))
 
 
-def handler(event, context):
+def handler(event, context) -> None:
     """
     Function called by the lambda to upload the enriched judgment to vlex
     """

--- a/src/lambdas/xml_validate/index.py
+++ b/src/lambdas/xml_validate/index.py
@@ -10,6 +10,7 @@ from aws_lambda_powertools.utilities.data_classes import S3Event, event_source
 from aws_lambda_powertools.utilities.data_classes.s3_event import S3EventRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from lxml import etree
+from mypy_boto3_sqs.type_defs import MessageAttributeValueQueueTypeDef
 
 from utils.environment_helpers import validate_env_variable
 
@@ -108,7 +109,7 @@ def trigger_push_enriched(uploaded_bucket, uploaded_key):
 
     # Create a new message
     message = {"Validated": uploaded_key}
-    msg_attributes = {
+    msg_attributes: dict[str, MessageAttributeValueQueueTypeDef] = {
         "source_key": {"DataType": "String", "StringValue": uploaded_key},
         "source_bucket": {"DataType": "String", "StringValue": uploaded_bucket},
     }

--- a/src/lambdas/xml_validate/requirements.txt
+++ b/src/lambdas/xml_validate/requirements.txt
@@ -1,1 +1,2 @@
 lxml==4.9.3
+aws_lambda_powertools==2.30.2

--- a/src/legislation_extraction/requirements.txt
+++ b/src/legislation_extraction/requirements.txt
@@ -5,3 +5,4 @@ pandas==2.1.4
 # psycopg2==2.9.3
 psycopg2-binary==2.9.9
 sqlalchemy==2.0.23
+aws_lambda_powertools==2.30.2

--- a/src/legislation_provisions_extraction/legislation_provisions.py
+++ b/src/legislation_provisions_extraction/legislation_provisions.py
@@ -68,11 +68,11 @@ def find_closest_legislation(legislations, sections, thr=30):
     return section_to_leg
 
 
-def get_clean_section_number(section):
+def get_clean_section_number(section: str) -> str:
     """
     Cleans just the section number.
     :param section: section to return the number for
-    :returns section_number: returns numbers from section
+    :returns section_number: returns numbers from section as a string
     """
     section_number = re.findall(r"\d+", section)
     return section_number[0]

--- a/src/legislation_provisions_extraction/legislation_provisions.py
+++ b/src/legislation_provisions_extraction/legislation_provisions.py
@@ -101,7 +101,7 @@ def save_section_to_dict(section_dict, para_number, clean_section_dict):
         clean_section = "section " + str(section_number)
 
         # creates the canonical form for subsection
-        sub_canonical = canonical + " s. " + section_number if canonical else ""
+        sub_canonical = f"{canonical} s. {section_number}" if canonical else ""
 
         # new dictionary with the relevant information for the entry
         new_definition = {

--- a/src/legislation_provisions_extraction/legislation_provisions.py
+++ b/src/legislation_provisions_extraction/legislation_provisions.py
@@ -17,7 +17,7 @@ import re
 from typing import Any, Dict, List
 
 import numpy as np
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from utils.proper_xml import create_tag_string
 from utils.types import DocumentAsXMLString
@@ -91,6 +91,8 @@ def save_section_to_dict(section_dict, para_number, clean_section_dict):
         section_number = get_clean_section_number(section)
         soup = BeautifulSoup(full_ref, "xml")
         ref = soup.find("ref")
+        if not isinstance(ref, Tag):
+            raise ValueError("Did not successfully get <ref> tag")
         canonical = ref.get("canonical")  # get the legislation canonical form
         leg_href = ref.get("href")  # get the legislation href
         section_href = (

--- a/src/legislation_provisions_extraction/legislation_provisions.py
+++ b/src/legislation_provisions_extraction/legislation_provisions.py
@@ -20,6 +20,7 @@ import numpy as np
 from bs4 import BeautifulSoup
 
 from utils.proper_xml import create_tag_string
+from utils.types import DocumentAsXMLString
 
 SectionDict = Dict[str, List[Any]]  # this is a guess
 
@@ -295,7 +296,7 @@ def main(enriched_judgment_file_path, filename):
     return resolved_refs
 
 
-def provisions_pipeline(file_data):
+def provisions_pipeline(file_data: DocumentAsXMLString) -> list:
     """
     Matches all sections in the judgment to the correct legislation and provides necessary information for the replacements.
     :param file_data: file path of the judgment

--- a/src/legislation_provisions_extraction/requirements.txt
+++ b/src/legislation_provisions_extraction/requirements.txt
@@ -2,3 +2,4 @@
 numpy==1.26.2
 beautifulsoup4==4.12.2
 lxml==4.9.3
+aws_lambda_powertools==2.30.2

--- a/src/oblique_references/enrich_oblique_references.py
+++ b/src/oblique_references/enrich_oblique_references.py
@@ -6,9 +6,10 @@ from oblique_references.oblique_references import (
     get_oblique_reference_replacements_by_paragraph,
 )
 from replacer.second_stage_replacer import replace_references_by_paragraph
+from utils.types import DocumentAsXMLString
 
 
-def enrich_oblique_references(file_content: str) -> str:
+def enrich_oblique_references(file_content: DocumentAsXMLString) -> DocumentAsXMLString:
     """
     Determines oblique references in the file_content and then returns
         an enriched file content with the replacements applied

--- a/src/oblique_references/requirements.txt
+++ b/src/oblique_references/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.3
+aws_lambda_powertools==2.30.2

--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -7,7 +7,12 @@ import lxml.etree
 from bs4 import BeautifulSoup
 
 from replacer.replacer_pipeline import replacer_pipeline
-from utils.types import DocumentAsXMLString, Reference, XMLFragmentAsString
+from utils.types import (
+    DocumentAsXMLString,
+    Reference,
+    Replacement,
+    XMLFragmentAsString,
+)
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
@@ -76,9 +81,9 @@ def apply_replacements(
     Run the replacer pipeline to make replacements on caselaw, legislation and abbreviations
     """
 
-    case_replacement_patterns = []
-    leg_replacement_patterns = []
-    abb_replacement_patterns = []
+    case_replacement_patterns: list[Replacement] = []
+    leg_replacement_patterns: list[Replacement] = []
+    abb_replacement_patterns: list[Replacement] = []
 
     for replacement_pattern_json in replacement_patterns.splitlines():
         LOGGER.debug(replacement_pattern_json)

--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -7,7 +7,7 @@ import lxml.etree
 from bs4 import BeautifulSoup
 
 from replacer.replacer_pipeline import replacer_pipeline
-from utils.types import DocumentAsXMLString, Reference
+from utils.types import DocumentAsXMLString, Reference, XMLFragmentAsString
 
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.DEBUG)
@@ -70,8 +70,8 @@ def make_post_header_replacements(
 
 
 def apply_replacements(
-    content: DocumentAsXMLString, replacement_patterns: str
-) -> DocumentAsXMLString:
+    content: XMLFragmentAsString, replacement_patterns: str
+) -> XMLFragmentAsString:
     """
     Run the replacer pipeline to make replacements on caselaw, legislation and abbreviations
     """
@@ -153,7 +153,9 @@ def _remove_old_enrichment_references(
     return DocumentAsXMLString(lxml.etree.tostring(result).decode("utf-8"))
 
 
-def split_text_by_closing_header_tag(content: str) -> tuple[str, str, str]:
+def split_text_by_closing_header_tag(
+    content: DocumentAsXMLString,
+) -> tuple[XMLFragmentAsString, XMLFragmentAsString, XMLFragmentAsString]:
     """
     Split content into start, closing header tag and body
     to ensure replacements only occur in the body.
@@ -162,5 +164,14 @@ def split_text_by_closing_header_tag(content: str) -> tuple[str, str, str]:
     for pattern in header_patterns:
         if pattern not in content:
             continue
-        return content.partition(pattern)
-    return "", "", content
+
+        return (
+            XMLFragmentAsString(content.partition(pattern)[0]),
+            XMLFragmentAsString(content.partition(pattern)[1]),
+            XMLFragmentAsString(content.partition(pattern)[2]),
+        )  # This cannot be a list comprehension because we need to know the length of the tuple
+    return (
+        XMLFragmentAsString(""),
+        XMLFragmentAsString(""),
+        XMLFragmentAsString(content),
+    )

--- a/src/replacer/replacer.py
+++ b/src/replacer/replacer.py
@@ -5,8 +5,10 @@ Handles the replacements of abbreviations, legislation, and case law.
 
 import json
 
+from utils.types import Replacement
 
-def write_replacements_file(replacement_list):
+
+def write_replacements_file(replacement_list: list[Replacement]) -> str:
     """
     Writes tuples from a list
     :param replacement_list:

--- a/src/replacer/replacer_pipeline.py
+++ b/src/replacer/replacer_pipeline.py
@@ -8,7 +8,7 @@ import re
 from typing import Optional
 
 from utils.proper_xml import create_tag_string
-from utils.types import Replacement, DocumentAsXMLString
+from utils.types import Replacement, XMLFragmentAsString
 
 
 def fixed_year(year: str) -> Optional[str]:
@@ -24,8 +24,8 @@ def fixed_year(year: str) -> Optional[str]:
 
 
 def replacer_caselaw(
-    file_data: DocumentAsXMLString, replacement: Replacement
-) -> DocumentAsXMLString:
+    file_data: XMLFragmentAsString, replacement: Replacement
+) -> XMLFragmentAsString:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -45,14 +45,14 @@ def replacer_caselaw(
     attribs["uk:origin"] = "TNA"
     replacement_string = create_tag_string("ref", html.escape(replacement[0]), attribs)
 
-    return DocumentAsXMLString(
+    return XMLFragmentAsString(
         str(file_data).replace(replacement[0], replacement_string)
     )
 
 
 def replacer_leg(
-    file_data: DocumentAsXMLString, replacement: Replacement
-) -> DocumentAsXMLString:
+    file_data: XMLFragmentAsString, replacement: Replacement
+) -> XMLFragmentAsString:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -66,14 +66,14 @@ def replacer_leg(
         "uk:origin": "TNA",
     }
     replacement_string = create_tag_string("ref", html.escape(replacement[0]), attribs)
-    return DocumentAsXMLString(
+    return XMLFragmentAsString(
         str(file_data).replace(replacement[0], replacement_string)
     )
 
 
 def replacer_abbr(
-    file_data: DocumentAsXMLString, replacement: Replacement
-) -> DocumentAsXMLString:
+    file_data: XMLFragmentAsString, replacement: Replacement
+) -> XMLFragmentAsString:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -83,17 +83,17 @@ def replacer_abbr(
     replacement_string = (
         f'<abbr title="{replacement[1]}" uk:origin="TNA">{replacement[0]}</abbr>'
     )
-    return DocumentAsXMLString(
+    return XMLFragmentAsString(
         str(file_data).replace(str(replacement[0]), replacement_string)
     )
 
 
 def replacer_pipeline(
-    file_data: DocumentAsXMLString,
+    file_data: XMLFragmentAsString,
     REPLACEMENTS_CASELAW: list[Replacement],
     REPLACEMENTS_LEG: list[Replacement],
     REPLACEMENTS_ABBR: list[Replacement],
-) -> DocumentAsXMLString:
+) -> XMLFragmentAsString:
     """
     Pipeline to run replacer_caselaw, replacer_leg, replacer_abbr
     :param file_data: XML file

--- a/src/replacer/replacer_pipeline.py
+++ b/src/replacer/replacer_pipeline.py
@@ -8,7 +8,7 @@ import re
 from typing import Optional
 
 from utils.proper_xml import create_tag_string
-from utils.types import Replacement
+from utils.types import Replacement, DocumentAsXMLString
 
 
 def fixed_year(year: str) -> Optional[str]:
@@ -23,7 +23,9 @@ def fixed_year(year: str) -> Optional[str]:
         return None
 
 
-def replacer_caselaw(file_data: str, replacement: Replacement) -> str:
+def replacer_caselaw(
+    file_data: DocumentAsXMLString, replacement: Replacement
+) -> DocumentAsXMLString:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -43,11 +45,14 @@ def replacer_caselaw(file_data: str, replacement: Replacement) -> str:
     attribs["uk:origin"] = "TNA"
     replacement_string = create_tag_string("ref", html.escape(replacement[0]), attribs)
 
-    file_data = str(file_data).replace(replacement[0], replacement_string)
-    return file_data
+    return DocumentAsXMLString(
+        str(file_data).replace(replacement[0], replacement_string)
+    )
 
 
-def replacer_leg(file_data: str, replacement: Replacement) -> str:
+def replacer_leg(
+    file_data: DocumentAsXMLString, replacement: Replacement
+) -> DocumentAsXMLString:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -61,11 +66,14 @@ def replacer_leg(file_data: str, replacement: Replacement) -> str:
         "uk:origin": "TNA",
     }
     replacement_string = create_tag_string("ref", html.escape(replacement[0]), attribs)
-    file_data = str(file_data).replace(replacement[0], replacement_string)
-    return file_data
+    return DocumentAsXMLString(
+        str(file_data).replace(replacement[0], replacement_string)
+    )
 
 
-def replacer_abbr(file_data: str, replacement: Replacement) -> str:
+def replacer_abbr(
+    file_data: DocumentAsXMLString, replacement: Replacement
+) -> DocumentAsXMLString:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -75,16 +83,17 @@ def replacer_abbr(file_data: str, replacement: Replacement) -> str:
     replacement_string = (
         f'<abbr title="{replacement[1]}" uk:origin="TNA">{replacement[0]}</abbr>'
     )
-    file_data = str(file_data).replace(str(replacement[0]), replacement_string)
-    return file_data
+    return DocumentAsXMLString(
+        str(file_data).replace(str(replacement[0]), replacement_string)
+    )
 
 
 def replacer_pipeline(
-    file_data: str,
+    file_data: DocumentAsXMLString,
     REPLACEMENTS_CASELAW: list[Replacement],
     REPLACEMENTS_LEG: list[Replacement],
     REPLACEMENTS_ABBR: list[Replacement],
-) -> str:
+) -> DocumentAsXMLString:
     """
     Pipeline to run replacer_caselaw, replacer_leg, replacer_abbr
     :param file_data: XML file

--- a/src/replacer/replacer_pipeline.py
+++ b/src/replacer/replacer_pipeline.py
@@ -5,11 +5,13 @@ Handles the replacements of abbreviations, legislation, and case law.
 
 import html
 import re
+from typing import Optional
 
 from utils.proper_xml import create_tag_string
+from utils.types import Replacement
 
 
-def fixed_year(year):
+def fixed_year(year: str) -> Optional[str]:
     """For some reason, years can be returned as "No Year", despite not being present in the code (outside tests) or the database
     (as far as I can see."""
     if not year:
@@ -21,7 +23,7 @@ def fixed_year(year):
         return None
 
 
-def replacer_caselaw(file_data, replacement):
+def replacer_caselaw(file_data: str, replacement: Replacement) -> str:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -45,7 +47,7 @@ def replacer_caselaw(file_data, replacement):
     return file_data
 
 
-def replacer_leg(file_data, replacement):
+def replacer_leg(file_data: str, replacement: Replacement) -> str:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -63,7 +65,7 @@ def replacer_leg(file_data, replacement):
     return file_data
 
 
-def replacer_abbr(file_data, replacement):
+def replacer_abbr(file_data: str, replacement: Replacement) -> str:
     """
     String replacement in the XML
     :param file_data: XML file
@@ -78,8 +80,11 @@ def replacer_abbr(file_data, replacement):
 
 
 def replacer_pipeline(
-    file_data, REPLACEMENTS_CASELAW, REPLACEMENTS_LEG, REPLACEMENTS_ABBR
-):
+    file_data: str,
+    REPLACEMENTS_CASELAW: list[Replacement],
+    REPLACEMENTS_LEG: list[Replacement],
+    REPLACEMENTS_ABBR: list[Replacement],
+) -> str:
     """
     Pipeline to run replacer_caselaw, replacer_leg, replacer_abbr
     :param file_data: XML file

--- a/src/replacer/requirements.txt
+++ b/src/replacer/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.3
+aws_lambda_powertools==2.30.2

--- a/src/replacer/second_stage_replacer.py
+++ b/src/replacer/second_stage_replacer.py
@@ -9,7 +9,7 @@ import re
 from itertools import groupby
 from typing import Dict, Iterable, List, Tuple, Union
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 LegislationReference = Tuple[Tuple[int, int], str]
 LegislationReferenceReplacements = List[Dict[str, Union[str, int]]]
@@ -67,12 +67,14 @@ def replace_references(
 def create_replacement_paragraph(
     paragraph_string: str,
     paragraph_reference_replacements: Iterable[dict[str, str | int]],
-) -> BeautifulSoup:
+) -> Tag:
     replacement_paragraph_string = replace_references(
         paragraph_string, list(paragraph_reference_replacements)
     )
     wrapper = f'<xml xmlns:uk="placeholder">{replacement_paragraph_string}</xml>'
     replacement_paragraph = BeautifulSoup(wrapper, "xml").p
+    if replacement_paragraph is None:
+        raise RuntimeError(f"No paragraphs found in {replacement_paragraph_string}")
     return replacement_paragraph
 
 

--- a/src/replacer/second_stage_replacer.py
+++ b/src/replacer/second_stage_replacer.py
@@ -11,6 +11,8 @@ from typing import Iterable, TypedDict
 
 from bs4 import BeautifulSoup, Tag
 
+from utils.types import DocumentAsXMLString
+
 LegislationReference = tuple[tuple[int, int], str]
 
 
@@ -87,7 +89,7 @@ def create_replacement_paragraph(
 def replace_references_by_paragraph(
     file_data: BeautifulSoup,
     reference_replacements: list[LegislationReferenceReplacement],
-) -> str:
+) -> DocumentAsXMLString:
     """
     Replaces references in the file_data xml by paragraph
     :param file_data: XML file
@@ -110,4 +112,4 @@ def replace_references_by_paragraph(
                 paragraph_string, paragraph_reference_replacements
             )
         )
-    return str(file_data)
+    return DocumentAsXMLString(str(file_data))

--- a/src/tests/lambda_tests/determine_legislation_provisions/test_determine_legislation_provisions.py
+++ b/src/tests/lambda_tests/determine_legislation_provisions/test_determine_legislation_provisions.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-import lxml
+import lxml.etree
 
 os.environ["DEST_BUCKET"] = "PLACEHOLDER"
 from lambdas.determine_legislation_provisions.index import (  # noqa: E402

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -18,3 +18,5 @@ SPARQLWrapper==2.0.0
 python-dotenv==1.0.0
 rapidfuzz==3.5.2
 ds-caselaw-marklogic-api-client==18.0.0
+boto3-stubs[essential] == 1.28.55
+aws_lambda_powertools == 2.30.2

--- a/src/utils/environment_helpers.py
+++ b/src/utils/environment_helpers.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 
-def validate_env_variable(env_var_name):
+def validate_env_variable(env_var_name: str) -> str:
     print(f"Getting the value of the environment variable: {env_var_name}")
 
     try:

--- a/src/utils/environment_helpers.py
+++ b/src/utils/environment_helpers.py
@@ -24,7 +24,7 @@ def validate_env_variable(env_var_name: str) -> str:
     return env_variable
 
 
-def get_aws_secret(aws_secret_name, aws_region_name):
+def get_aws_secret(aws_secret_name: str, aws_region_name: str) -> str | bytes:
     """
     Get aws secret
     """
@@ -43,16 +43,11 @@ def get_aws_secret(aws_secret_name, aws_region_name):
         # Decrypts secret using the associated KMS CMK.
         # Depending on whether the secret is a string or binary, one of these fields will be populated.
         if "SecretString" in get_secret_value_response:
-            secret = get_secret_value_response["SecretString"]
             LOGGER.info("got SecretString")
+            return get_secret_value_response["SecretString"]
         else:
             LOGGER.info("not SecretString")
-            decoded_binary_secret = base64.b64decode(
-                get_secret_value_response["SecretBinary"]
-            )
-            secret = decoded_binary_secret
-        LOGGER.info("here")
-        return secret
+            return base64.b64decode(get_secret_value_response["SecretBinary"])
     # added as the validation exception was not being caught
     except Exception as exception:
         LOGGER.error("Exception: %s", exception)

--- a/src/utils/helper.py
+++ b/src/utils/helper.py
@@ -6,8 +6,10 @@ import re
 
 import bs4 as BeautifulSoup
 
+from utils.types import DocumentAsXMLString
 
-def parse_file(file_data):
+
+def parse_file(file_data: DocumentAsXMLString) -> str:
     """
     Parse XML file. Only get text within content elements
     :param file_data: XML file

--- a/src/utils/initialise_db.py
+++ b/src/utils/initialise_db.py
@@ -45,7 +45,7 @@ def init_db_connection() -> psycopg2.extensions.connection:
     )
 
 
-def _get_database_password():
+def _get_database_password() -> str:
     aws_secret_name = validate_env_variable("SECRET_PASSWORD_LOOKUP")
     aws_region_name = validate_env_variable("REGION_NAME")
     return get_aws_secret(aws_secret_name, aws_region_name)

--- a/src/utils/proper_xml.py
+++ b/src/utils/proper_xml.py
@@ -32,5 +32,5 @@ def create_tag(
     return root
 
 
-def create_tag_string(*args, **kwargs) -> str:
-    return lxml.etree.tostring(create_tag(*args, **kwargs)).decode("utf-8")
+def create_tag_string(tag: str, contents: str = "", attrs: Optional[dict[str, str]] = None) -> str:
+    return lxml.etree.tostring(create_tag(tag=tag, contents=contents, attrs=attrs)).decode("utf-8")

--- a/src/utils/proper_xml.py
+++ b/src/utils/proper_xml.py
@@ -32,5 +32,9 @@ def create_tag(
     return root
 
 
-def create_tag_string(tag: str, contents: str = "", attrs: Optional[dict[str, str]] = None) -> str:
-    return lxml.etree.tostring(create_tag(tag=tag, contents=contents, attrs=attrs)).decode("utf-8")
+def create_tag_string(
+    tag: str, contents: str = "", attrs: Optional[dict[str, str]] = None
+) -> str:
+    return lxml.etree.tostring(
+        create_tag(tag=tag, contents=contents, attrs=attrs)
+    ).decode("utf-8")

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -1,12 +1,14 @@
 from typing import NewType
 
+import spacy
+
 Replacement = NewType("Replacement", tuple[str, str, str, str, bool])
 # ('[2022] UKSC 3', '[2022] UKSC 3', '2022', 'https://caselaw.nationalarchives.gov.uk/uksc/2022/3', True)
 
 Reference = list[tuple[tuple[int, int], str]]
 # The first part is a span (from inter-character-position to another) and the second is the string found there
 
-
+NLPModel = spacy.lang.en.English
 # from typing import TypeAlias
 # Replacement: TypeAlias = Iterable
 

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -12,3 +12,6 @@ Reference = list[tuple[tuple[int, int], str]]
 
 APIEndpointBaseURL = NewType("APIEndpointBaseURL", str)
 """ A string representing the endpoint URL of an FCL Privileged API instance. """
+
+DocumentAsXMLString = NewType("DocumentAsXMLString", str)
+""" An entire document as a string representation of XML. """

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -1,0 +1,11 @@
+from typing import NewType
+
+Replacement = NewType("Replacement", tuple[str, str, str, str, bool])
+# ('[2022] UKSC 3', '[2022] UKSC 3', '2022', 'https://caselaw.nationalarchives.gov.uk/uksc/2022/3', True)
+
+Reference = list[tuple[tuple[int, int], str]]
+# The first part is a span (from inter-character-position to another) and the second is the string found there
+
+
+# from typing import TypeAlias
+# Replacement: TypeAlias = Iterable

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -13,6 +13,9 @@ Reference = list[tuple[tuple[int, int], str]]
 APIEndpointBaseURL = NewType("APIEndpointBaseURL", str)
 """ A string representing the endpoint URL of an FCL Privileged API instance. """
 
+XMLFragmentAsString = NewType("XMLFragmentAsString", str)
+""" A string representation of some XML. """
+
 DocumentAsXMLString = NewType("DocumentAsXMLString", str)
 """ An entire document as a string representation of XML. """
 

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -9,3 +9,6 @@ Reference = list[tuple[tuple[int, int], str]]
 
 # from typing import TypeAlias
 # Replacement: TypeAlias = Iterable
+
+APIEndpointBaseURL = NewType("APIEndpointBaseURL", str)
+""" A string representing the endpoint URL of an FCL Privileged API instance. """

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -15,3 +15,6 @@ APIEndpointBaseURL = NewType("APIEndpointBaseURL", str)
 
 DocumentAsXMLString = NewType("DocumentAsXMLString", str)
 """ An entire document as a string representation of XML. """
+
+DocumentAsXMLBytes = NewType("DocumentAsXMLBytes", bytes)
+""" An entire document as a bytestring representation of XML. """


### PR DESCRIPTION
Enrichment has a lot of moving parts which need to be able to reliably pass data between them. Adding thorough type annotations gives us massively increased confidence in what is actually happening, reducing scope for errors to creep in. Amongst other things, this PR:

- Adds a bunch of type extensions to mypy for greater introspection ability
- Improves module discovery so static analysis can get a better handle on imports
- Makes use of [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) to give us more strongly typed interactions with Lambda trigger events
- Creates some new type classes so we can be more confident in what we're passing around
- Deduplicates some functions where obvious to assist in typing
- Makes a bunch of type declarations
