### PR TITLE
Be flexible about soup namespaces for canonical§

### DIFF
--- a/src/oblique_references/oblique_references.py
+++ b/src/oblique_references/oblique_references.py
@@ -85,7 +85,7 @@ def create_legislation_dict(
         legislation_name = ref.text if not None else ""
 
         href = ref.get("href")
-        canonical = ref.get("canonical")
+        canonical = ref.get("uk:canonical") or ref.get("canonical")
 
         if not isinstance(href, str):
             raise NotExactlyOneRefTag(

--- a/src/tests/oblique_reference_extraction_tests/test_oblique_references.py
+++ b/src/tests/oblique_reference_extraction_tests/test_oblique_references.py
@@ -134,7 +134,7 @@ class TestCreateLegislationDict(unittest.TestCase):
             ),
             (
                 (588, 733),
-                '<ref href="http://www.legislation.gov.uk/id/ukpga/2004/12" uk:canonical="2004 c. 12" uk:origin="TNA" uk:type="legislation">Finance Act 2004</ref>',
+                '<ref href="http://www.legislation.gov.uk/id/ukpga/2004/12" uk:canonical="2004 c. 12" uk:origin="TNA" uk:type="legislation" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">Finance Act 2004</ref>',
             ),
         ]
         paragraph_number = 2


### PR DESCRIPTION
Permit `uk:canonical` or `canonical` as attributes of ref tags