### PR TITLE
Revert "Add spacy to all the requirements"

### DIFF
--- a/src/database/requirements.txt
+++ b/src/database/requirements.txt
@@ -1,4 +1,3 @@
 pandas==2.1.4
 psycopg2==2.9.9
 sqlalchemy==2.0.24
-spacy==3.7.2

--- a/src/lambdas/db_backup/requirements.txt
+++ b/src/lambdas/db_backup/requirements.txt
@@ -1,4 +1,3 @@
 boto3==1.34.11
 botocore==1.34.11
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/extract_judgement_contents/requirements.txt
+++ b/src/lambdas/extract_judgement_contents/requirements.txt
@@ -2,4 +2,3 @@ beautifulsoup4==4.12.2
 lxml==4.9.4
 pandas==2.1.4
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/fetch_xml/requirements.txt
+++ b/src/lambdas/fetch_xml/requirements.txt
@@ -2,4 +2,3 @@ requests==2.31.0
 boto3==1.34.11
 botocore==1.34.11
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/make_replacements/requirements.txt
+++ b/src/lambdas/make_replacements/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.4
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/push_enriched_xml/requirements.txt
+++ b/src/lambdas/push_enriched_xml/requirements.txt
@@ -2,4 +2,3 @@ requests==2.31.0
 boto3==1.34.11
 botocore==1.34.11
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/update_legislation_table/requirements.txt
+++ b/src/lambdas/update_legislation_table/requirements.txt
@@ -3,4 +3,3 @@ pandas==2.1.4
 sqlalchemy==2.0.24
 SPARQLWrapper==2.0.0
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/update_rules_processor/requirements.txt
+++ b/src/lambdas/update_rules_processor/requirements.txt
@@ -5,4 +5,3 @@ boto3==1.34.11
 spacy==3.7.2
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/lambdas/xml_validate/requirements.txt
+++ b/src/lambdas/xml_validate/requirements.txt
@@ -1,3 +1,2 @@
 lxml==4.9.4
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/legislation_provisions_extraction/requirements.txt
+++ b/src/legislation_provisions_extraction/requirements.txt
@@ -3,4 +3,3 @@ numpy==1.26.2
 beautifulsoup4==4.12.2
 lxml==4.9.4
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/oblique_references/requirements.txt
+++ b/src/oblique_references/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.4
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/replacer/requirements.txt
+++ b/src/replacer/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.4
 aws_lambda_powertools==2.30.2
-spacy==3.7.2

--- a/src/utils/requirements.txt
+++ b/src/utils/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4==4.12.2
 lxml==4.9.4
 pandas==2.1.4
-spacy==3.7.2


### PR DESCRIPTION
This reverts commit 5e30979763fb04132b0cbd9e262351fd1d9ea1dd.

We don't need it because we're only importing spacy for type checking.

- \[ \] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- \[ \] Update CHANGELOG.md
