### PR TITLE
Remove all NLP typing

### DIFF
--- a/src/abbreviation_extraction/abbreviations_matcher.py
+++ b/src/abbreviation_extraction/abbreviations_matcher.py
@@ -6,7 +6,6 @@ AbbreviationDetector class and the pipeline.
 
 from collections import namedtuple
 
-import spacy
 from spacy.language import Language
 
 from abbreviation_extraction.abbreviations import AbbreviationDetector
@@ -41,7 +40,7 @@ def chunking_mechanism(docobj, n, start, end):
     return judgment_chunks
 
 
-def abb_pipeline(judgment_content_text: str, nlp: spacy.lang.en.English) -> list[abb]:
+def abb_pipeline(judgment_content_text: str, nlp) -> list[abb]:
     """
     Main controller of the abbreviation detection pipeline.
     :param judgment_content_text: judgment content
@@ -54,9 +53,7 @@ def abb_pipeline(judgment_content_text: str, nlp: spacy.lang.en.English) -> list
 
     # init the class - stateful pipeline component
     @Language.factory("abbreviation_detector")
-    def create_abbreviation_detector(
-        nlp: spacy.lang.en.English, name: str
-    ) -> AbbreviationDetector:
+    def create_abbreviation_detector(nlp, name: str) -> AbbreviationDetector:
         return AbbreviationDetector(nlp)
 
     nlp.add_pipe("abbreviation_detector", last=True)

--- a/src/lambdas/determine_replacements_abbreviations/index.py
+++ b/src/lambdas/determine_replacements_abbreviations/index.py
@@ -109,7 +109,7 @@ def get_abbreviation_replacements(file_content: str) -> list[abb]:
     return replacements
 
 
-def init_NLP() -> spacy.lang.en.English:
+def init_NLP():
     """
     Load spacy model
     """

--- a/src/lambdas/determine_replacements_legislation/index.py
+++ b/src/lambdas/determine_replacements_legislation/index.py
@@ -124,7 +124,7 @@ def upload_replacements(
     return object.key
 
 
-def init_NLP() -> spacy.lang.en.English:
+def init_NLP():
     """
     Load spacy model
     """


### PR DESCRIPTION
We're getting `module 'spacy.lang' has no attribute 'en'` errors in determine-replacements-legislation. There's probably a reasonable way of doing this but let's not right now.