### PR TITLE
Auto unlock if timeout

### DIFF
--- a/src/lambdas/fetch_xml/index.py
+++ b/src/lambdas/fetch_xml/index.py
@@ -42,9 +42,15 @@ def lock_judgment_urllib(
     Lock the judgment for editing
     """
     http = urllib3.PoolManager()
-    url = f"{api_endpoint}lock/{query}"
+    # currently unlock only looks for a truthy/falsy value
+    # but we might upgrade that to be a time in seconds
+    url = f"{api_endpoint}lock/{query}?unlock=3600"
     headers = urllib3.make_headers(basic_auth=username + ":" + pw)
-    r = http.request("PUT", url, headers=headers)
+    r = http.request(
+        "PUT",
+        url,
+        headers=headers,
+    )
     print("Lock judgment API status:", r.status)
     # return r.data.decode()
 


### PR DESCRIPTION
We set an `expires` value that isn't 0; that will make it any lock expire at midnight. It's set to 3600 to make it less painful if/when we change the behaviour to expiring in a number of seconds.

This will need updating in api client and priv api.