### PR TITLE
Remove ref tags that have no uk:origin attribute

### DIFF
--- a/src/replacer/make_replacments.py
+++ b/src/replacer/make_replacments.py
@@ -32,11 +32,15 @@ xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
     </xsl:copy>
 </xsl:template>
 
+<!-- delete ref tags with origin=TNA attribute -->
 <xsl:template match="akn:ref[@uk:origin='TNA']">
     <xsl:apply-templates/>
 </xsl:template>
 
-<!-- <xsl:template match="reg"/> -->
+<!-- delete ref tags with no origin attribute -->
+<xsl:template match="akn:ref[not(@uk:origin)]">
+    <xsl:apply-templates/>
+</xsl:template>
 
 </xsl:stylesheet>
 """
@@ -147,7 +151,8 @@ def _remove_old_enrichment_references(
     file_content: DocumentAsXMLString,
 ) -> DocumentAsXMLString:
     """
-    Enrichment creates <ref uk:origin="TNA"> tags; delete only these.
+    Enrichment creates <ref uk:origin="TNA"> tags; delete these.
+    vCite enrichment created <ref> tags with no uk:origin, delete these too.
     """
     root = lxml.etree.fromstring(file_content.encode("utf-8"))
 

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -52,7 +52,7 @@ class TestMakePostHeaderReplacements:
 
         assert_equal_xml(content_with_replacements, expected_file_content)
 
-    def test_remove_legislation_references(self):
+    def test_remove_nested_legislation_references(self):
         tidy_output = _remove_old_enrichment_references(
             """
             <xml xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0' xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
@@ -61,8 +61,19 @@ class TestMakePostHeaderReplacements:
         )
 
         assert "<a><e><b>AAA</b><c/>D</e></a>" in tidy_output
+
+    def test_dont_delete_not_TNA_ref_tags(self):
         assert "not-TNA" in _remove_old_enrichment_references(
-            '<akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"><ref uk:origin="not-TNA"></ref></akomaNtoso>'
+            """<xml xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0' xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <ref uk:origin="not-TNA"></ref>
+            </xml>"""
+        )
+
+    def test_delete_no_origin_ref_tags(self):
+        assert "ref" not in _remove_old_enrichment_references(
+            """<xml xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0' xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <ref></ref>
+            </xml>"""
         )
 
 


### PR DESCRIPTION
Whilst reparsing would fix this, it's good to be able to reenrich the old stuff without spurious failures which means the queue will never empty.

The uk:origin attribute does not exist for vCite-enriched judgments in the backlog.