### PR TITLE
Request lock release whilst sending XML to marklogic

### DIFF
--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -60,6 +60,7 @@ def patch_judgment_request(
         f"{api_endpoint}judgment/{query}",
         auth=HTTPBasicAuth(username, pw),
         data=data.encode(),
+        params={"unlock": True},
     )
     print(response)
     response.raise_for_status()
@@ -109,9 +110,6 @@ def process_event(sqs_rec: SQSRecord) -> None:
     patch_judgment_request(
         api_endpoint, judgment_uri, file_content, API_USERNAME, API_PASSWORD
     )
-
-    # release the lock
-    release_lock(api_endpoint, judgment_uri, API_USERNAME, API_PASSWORD)
 
 
 ############################################


### PR DESCRIPTION
Benefits from the updated version of the privileged API to ensure that the document is always unlocked after use -- will break unlocking if that other one hasn't been merged.

https://github.com/nationalarchives/ds-caselaw-privileged-api/pulls