### PR TITLE
Terraform GitHub OpenID Connect

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,6 +16,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_data"></a> [data](#module\_data) | ./modules/data | n/a |
+| <a name="module_github_oidc"></a> [github\_oidc](#module\_github\_oidc) | ./modules/github_oidc | n/a |
 | <a name="module_lambda_s3"></a> [lambda\_s3](#module\_lambda\_s3) | ./modules/lambda_s3 | n/a |
 | <a name="module_network"></a> [network](#module\_network) | ./modules/network | n/a |
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,3 +53,11 @@ module "data" {
   database_subnet_group_name = module.network.database_subnet_group_name
   default_security_group_id  = module.network.default_security_group_id
 }
+
+module "github_oidc" {
+  source = "./modules/github_oidc"
+
+  name        = "tna"
+  environment = var.app_env
+  github_repo = "nationalarchives/ds-caselaw-data-enrichment-service"
+}

--- a/terraform/modules/github_oidc/data.tf
+++ b/terraform/modules/github_oidc/data.tf
@@ -1,0 +1,7 @@
+data "external" "github_oidc_certificate_thumbprint" {
+  program = ["/bin/bash", "${path.module}/external-data-scripts/get-certificate-thumbprint.sh"]
+
+  query = {
+    host = local.github_oidc_host
+  }
+}

--- a/terraform/modules/github_oidc/external-data-scripts/get-certificate-thumbprint.sh
+++ b/terraform/modules/github_oidc/external-data-scripts/get-certificate-thumbprint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+eval "$(jq -r '@sh "HOST=\(.host)"')"
+
+THUMBPRINT="$(openssl s_client -connect "$HOST:443" < /dev/null 2>/dev/null | \
+  openssl x509 -fingerprint -noout -in /dev/stdin | \
+  cut -f2 -d'=' | \
+  tr -d ':' | \
+  tr '[:upper:]' '[:lower:]'
+)"
+
+jq -ncr --arg thumbprint "$THUMBPRINT" \
+  '{
+    thumbprint: $thumbprint
+  }'

--- a/terraform/modules/github_oidc/locals.tf
+++ b/terraform/modules/github_oidc/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  name             = var.name
+  environment      = var.environment
+  github_oidc_host = var.github_oidc_host
+  github_repo      = var.github_repo
+}

--- a/terraform/modules/github_oidc/main.tf
+++ b/terraform/modules/github_oidc/main.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://${local.github_oidc_host}"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.external.github_oidc_certificate_thumbprint.result.thumbprint]
+}
+
+data "aws_iam_policy_document" "github_oidc_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.github_oidc_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.github_oidc_host}:sub"
+      values   = ["repo:${local.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_oidc" {
+  name               = "${local.name}-${local.environment}-github-oidc"
+  description        = "${local.name} ${local.environment} GitHub OIDC"
+  assume_role_policy = data.aws_iam_policy_document.github_oidc_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_oidc_administrator_access" {
+  role       = aws_iam_role.github_oidc.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/terraform/modules/github_oidc/variables.tf
+++ b/terraform/modules/github_oidc/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Name of project"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name. This along with `name` will be prefixed to resource names"
+  type        = string
+}
+
+variable "github_oidc_host" {
+  description = "GitHub OpenID host name"
+  type        = string
+  default     = "token.actions.githubusercontent.com"
+}
+
+variable "github_repo" {
+  description = "The name of the repository (username/repo) to allow GitHub actions to run actions against the AWS account"
+  type        = string
+}


### PR DESCRIPTION
* Creates an OpenID Connect provider for GitHub, with permissions to only allow access from a specific repository.
* The certificate thumbprint has changed previously (when GitHub update their certificates), so a script has been added to get the latest thumbprint - which is then passed to the OpenID connect provider
* Currently the managed AdministratorAccess policy has been attached to the Role that the OpenID Connect provider is allowed to assume - Though we should determine minimum permissions and create our own policy.