### PR TITLE
Conditionally create GitHub OpenID Connect provider

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,8 @@ module "data" {
 module "github_oidc" {
   source = "./modules/github_oidc"
 
-  name        = "tna"
-  environment = var.app_env
-  github_repo = "nationalarchives/ds-caselaw-data-enrichment-service"
+  name                        = "tna"
+  environment                 = var.app_env
+  github_repo                 = "nationalarchives/ds-caselaw-data-enrichment-service"
+  github_oidc_create_provider = false
 }

--- a/terraform/modules/github_oidc/data.tf
+++ b/terraform/modules/github_oidc/data.tf
@@ -1,7 +1,17 @@
+data "aws_caller_identity" "current" {}
+
 data "external" "github_oidc_certificate_thumbprint" {
+  count = local.github_oidc_create_provider ? 1 : 0
+
   program = ["/bin/bash", "${path.module}/external-data-scripts/get-certificate-thumbprint.sh"]
 
   query = {
     host = local.github_oidc_host
   }
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = local.github_oidc_create_provider ? 0 : 1
+
+  arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.github_oidc_host}"
 }

--- a/terraform/modules/github_oidc/locals.tf
+++ b/terraform/modules/github_oidc/locals.tf
@@ -1,6 +1,8 @@
 locals {
-  name             = var.name
-  environment      = var.environment
-  github_oidc_host = var.github_oidc_host
-  github_repo      = var.github_repo
+  name                        = var.name
+  environment                 = var.environment
+  github_oidc_create_provider = var.github_oidc_create_provider
+  github_oidc_host            = var.github_oidc_host
+  github_repo                 = var.github_repo
+  github_oidc_provider        = local.github_oidc_create_provider ? aws_iam_openid_connect_provider.github[0] : data.aws_iam_openid_connect_provider.github[0]
 }

--- a/terraform/modules/github_oidc/main.tf
+++ b/terraform/modules/github_oidc/main.tf
@@ -1,7 +1,9 @@
 resource "aws_iam_openid_connect_provider" "github" {
+  count = local.github_oidc_create_provider ? 1 : 0
+
   url             = "https://${local.github_oidc_host}"
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.external.github_oidc_certificate_thumbprint.result.thumbprint]
+  thumbprint_list = [data.external.github_oidc_certificate_thumbprint[0].result.thumbprint]
 }
 
 data "aws_iam_policy_document" "github_oidc_assume_role_policy" {
@@ -9,7 +11,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role_policy" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github.arn]
+      identifiers = [local.github_oidc_provider.arn]
     }
 
     condition {

--- a/terraform/modules/github_oidc/variables.tf
+++ b/terraform/modules/github_oidc/variables.tf
@@ -8,6 +8,11 @@ variable "environment" {
   type        = string
 }
 
+variable "github_oidc_create_provider" {
+  description = "Conditionally create GitHub OpenID Connect provider. Only 1 provider configured with the GitHub url is allowed. Set to `false` to use the existing one."
+  type        = bool
+}
+
 variable "github_oidc_host" {
   description = "GitHub OpenID host name"
   type        = string


### PR DESCRIPTION
* Only 1 provider configured with the GitHub url is allowed
* This adds a variable `github_oidc_create_provider` to conditionally create the provider. Set to `false` if the provider already exists, and the trusted role will be created with the existing provider arn.
