### PR TITLE
Use OIDC for aws credentials

### DIFF
--- a/.github/workflows/cd_deploy_staging_then_prod.yml
+++ b/.github/workflows/cd_deploy_staging_then_prod.yml
@@ -19,8 +19,7 @@ jobs:
     name: Deploy Staging Build
     uses: ./.github/workflows/deploy_single_environment.yml
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       account_id: ${{ secrets.STAGING_ACCOUNT_ID }}
       workspace: tna-staging
       app_env: staging
@@ -31,8 +30,7 @@ jobs:
     uses: ./.github/workflows/deploy_single_environment.yml
     needs: deploy_staging
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+      aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN_PROD }}
       account_id: ${{ secrets.PROD_ACCOUNT_ID }}
       workspace: tna-prod
       app_env: production

--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -99,8 +99,7 @@ jobs:
   terraform_plan-staging:
     uses: ./.github/workflows/terraform_plan.yml
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       account_id: ${{ secrets.STAGING_ACCOUNT_ID }}
       workspace: tna-staging
       app_env: staging
@@ -108,8 +107,7 @@ jobs:
   terraform_plan-production:
     uses: ./.github/workflows/terraform_plan.yml
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+      aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN_PROD }}
       account_id: ${{ secrets.PROD_ACCOUNT_ID }}
       workspace: tna-prod
       app_env: production

--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -1,9 +1,7 @@
 on:
   workflow_call:
     secrets:
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
+      aws_oidc_role_arn:
         required: true
       account_id:
         required: true
@@ -27,11 +25,10 @@ jobs:
           python-version: "3.12"
 
       - name: Get AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-2
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          role-to-assume: ${{ secrets.aws_oidc_role_arn }}
         continue-on-error: false
 
       - name: Buildx

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -3,9 +3,7 @@ name: terraform_plan
 on:
   workflow_call:
     secrets:
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
+      aws_oidc_role_arn:
         required: true
       account_id:
         required: true
@@ -17,7 +15,9 @@ on:
 jobs:
   terraform_plan:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.1
@@ -29,11 +29,10 @@ jobs:
         continue-on-error: false
 
       - name: Get AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-2
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          role-to-assume: ${{ secrets.aws_oidc_role_arn }}
         continue-on-error: false
 
       - name: Terraform init


### PR DESCRIPTION
* Using OpenID Connect allows us to deploy to AWS qithout needing to manage access keys. The provider has been configured to allow gaining credentials from GitHub actions in this repository. The role it assumes is preovided as a GitHub secret (`AWS_OIDC_ROLE_ARN`/`AWS_OIDC_ROLE_ARN_PROD`)