### PR TITLE
Install SSM Agent on Jump Host

### DIFF
--- a/terraform/modules/jump_host/ec2-userdata/jump-host.tpl
+++ b/terraform/modules/jump_host/ec2-userdata/jump-host.tpl
@@ -3,6 +3,8 @@
 # Install useful packages
 sudo yum update -y
 
+sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+
 if ! command -v aws &> /dev/null
 then
   sudo yum install -y aws-cli


### PR DESCRIPTION
* The AWS SSM Agent isn't pre installed on Amazon Linux 2023 (Even though URL includes an ec2-downloads-windows directory, this is the correct installation files for Amazon Linux 2023 - https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-al2.html)