### PR TITLE
Add ability to create multiple RDS clusters

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,6 +55,17 @@ module "data" {
     module.network.default_security_group_id,
     module.jump_host.security_group_id,
   ]
+
+  aurora_rds = {
+    "main" = {
+      engine_version = "16.2"
+      instance_type  = "db.t3.medium"
+      allowed_security_groups = [
+        module.network.default_security_group_id,
+        module.jump_host.security_group_id,
+      ]
+    }
+  }
 }
 
 module "github_oidc" {

--- a/terraform/modules/data/aurora.tf
+++ b/terraform/modules/data/aurora.tf
@@ -1,0 +1,50 @@
+module "aurora-metadata-db" {
+  for_each = local.aurora_rds
+
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "5.3.0"
+
+  name = "${local.name}-${each.key}-metadata-db-${local.environment}"
+
+  engine         = "aurora-postgresql"
+  engine_version = each.value["engine_version"]
+  instance_type  = each.value["instance_type"]
+
+  vpc_id                  = var.vpc_id
+  subnets                 = data.aws_subnets.database.ids
+  create_security_group   = true
+  allowed_security_groups = each.value["allowed_security_groups"]
+
+  deletion_protection = local.db[local.environment].deletion_protection
+
+  password = aws_secretsmanager_secret_version.aurora_postgress_master_password[each.key].secret_string
+
+  apply_immediately   = true
+  skip_final_snapshot = true
+
+  db_parameter_group_name         = aws_db_parameter_group.example.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.example.id
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  database_name = "rules"
+
+  tags = local.tags
+}
+
+resource "aws_db_parameter_group" "aurora_postgres" {
+  for_each = local.aurora_rds
+
+  name        = "${local.name}-${each.key}-aurora-db-postgres11-parameter-group"
+  family      = "aurora-postgresql${split(".", each.value["engine_version"])[0]}"
+  description = "${local.name}-${each.key}-aurora-db-postgres${split(".", each.value["engine_version"])[0]}-parameter-group"
+  tags        = local.tags
+}
+
+resource "aws_rds_cluster_parameter_group" "aurora_postgres" {
+  for_each = local.aurora_rds
+
+  name        = "${local.name}-${each.key}-aurora-postgres${split(".", each.value["engine_version"])[0]}-cluster-parameter-group"
+  family      = "aurora-postgresql${split(".", each.value["engine_version"])[0]}"
+  description = "${local.name}-${each.key}-aurora-postgres${split(".", each.value["engine_version"])[0]}-cluster-parameter-group"
+  tags        = local.tags
+}

--- a/terraform/modules/data/locals.tf
+++ b/terraform/modules/data/locals.tf
@@ -12,6 +12,8 @@ locals {
     }
   }
 
+  aurora_rds = var.aurora_rds
+
   tags = {
     Environment = var.environment
     Project     = "TNA judgement enrichment"

--- a/terraform/modules/data/secrets.tf
+++ b/terraform/modules/data/secrets.tf
@@ -6,12 +6,36 @@ resource "random_password" "password" {
   override_special = "!#$%&*()-_=+[]"
 }
 
+resource "random_password" "aurora_password" {
+  for_each = local.aurora_rds
+
+  length  = 50
+  special = true
+  # Postgress passwords can't contain any of the following:
+  # / (slash), '(single quote), "(double quote) and @ (at sign).
+  override_special = "!#$%&*()-_=+[]"
+}
+
 resource "aws_secretsmanager_secret" "postgress_master_password" {
   name                    = "${local.name}-postgress-password-${local.environment}"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret" "aurora_postgress_master_password" {
+  for_each = local.aurora_rds
+
+  name                    = "${local.name}-${each.key}-postgress-password-${local.environment}"
   recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "postgress_master_password" {
   secret_id     = aws_secretsmanager_secret.postgress_master_password.id
   secret_string = random_password.password.result
+}
+
+resource "aws_secretsmanager_secret_version" "aurora_postgress_master_password" {
+  for_each = local.aurora_rds
+
+  secret_id     = aws_secretsmanager_secret.aurora_postgress_master_password[each.key].id
+  secret_string = random_password.aurora_password[each.key].result
 }

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -24,3 +24,11 @@ variable "environment" {
 variable "database_subnet_group_name" {
   type = string
 }
+
+variable "aurora_rds" {
+  type = map(object({
+    engine_version          = string
+    instance_type           = string
+    allowed_security_groups = list(string)
+  }))
+}


### PR DESCRIPTION
* This modifies the data module, so that a map of objects can be provided with configuration to launch multiple RDS clusters
* A configuration has been added to launch one called 'main', at the latest version
* Once this has been launched, and data migrated from the current RDS, the old terraform code can be removed to delete the original RDS cluster