### PR TITLE
Fix rds cluster attributes

### DIFF
--- a/terraform/modules/data/aurora.tf
+++ b/terraform/modules/data/aurora.tf
@@ -28,13 +28,19 @@ module "aurora-metadata-db" {
 
   database_name = "rules"
 
+  depends_on = [
+    aws_db_parameter_group.aurora_postgres,
+    aws_rds_cluster_parameter_group.aurora_postgres,
+    aws_secretsmanager_secret_version.aurora_postgress_master_password,
+  ]
+
   tags = local.tags
 }
 
 resource "aws_db_parameter_group" "aurora_postgres" {
   for_each = local.aurora_rds
 
-  name        = "${local.name}-${each.key}-aurora-db-postgres11-parameter-group"
+  name        = "${local.name}-${each.key}-aurora-db-postgres${split(".", each.value["engine_version"])[0]}-parameter-group"
   family      = "aurora-postgresql${split(".", each.value["engine_version"])[0]}"
   description = "${local.name}-${each.key}-aurora-db-postgres${split(".", each.value["engine_version"])[0]}-parameter-group"
   tags        = local.tags


### PR DESCRIPTION
* For some reason, when this is being applied, the error is being thrown:

> Error: Invalid index
> on modules/data/aurora.tf line 20, in module "aurora-metadata-db":
>  20:   password = aws_secretsmanager_secret_version.aurora_postgress_master_password[each.key].secret_string
>    ├────────────────
>    │ aws_secretsmanager_secret_version.aurora_postgress_master_password is object with no attributes
>    │ each.key is "main"

Which is weird, because it is being created (They all use the same local.aurora_rds in their `for_each`)

This is an attempt to add `depends_on` to force those resources to be evaluated first
