### PR TITLE
Fix default vpc RDS security groups

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,7 +41,7 @@ module "network" {
 
   environment = var.app_env
 
-  rds_security_group_id = module.data.rds_security_group_id
+  rds_security_group_ids = module.data.aurora_security_group_ids
 }
 
 module "data" {

--- a/terraform/modules/data/outputs.tf
+++ b/terraform/modules/data/outputs.tf
@@ -22,6 +22,6 @@ output "aws_subnets_private_ids" {
   value = toset(data.aws_subnets.private.ids)
 }
 
-output "rds_security_group_id" {
-  value = module.metadata-db.security_group_id
+output "aurora_security_group_ids" {
+  value = [for k, v in local.aurora_rds : module.aurora-metadata-db[k].security_group_id]
 }

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -18,6 +18,6 @@ variable "vpc_cidr_block" {
   default = "172.19.0.0/16"
 }
 
-variable "rds_security_group_id" {
-  type = string
+variable "rds_security_group_ids" {
+  type = list(string)
 }

--- a/terraform/modules/network/vpc.tf
+++ b/terraform/modules/network/vpc.tf
@@ -28,7 +28,7 @@ module "vpc" {
       protocol        = "tcp"
       from_port       = 5432
       to_port         = 5432
-      security_groups = var.rds_security_group_id
+      security_groups = join(",", var.rds_security_group_ids)
     }
   ]
 


### PR DESCRIPTION
* The security groups for the new RDS needs to be passed to the network module. It uses the terraform-aws-modules/vpc/aws module, which takes in a comma deliminated list of security group ids
