### PR TITLE
Update RDS CA Certificate Identifier

### DIFF
--- a/terraform/modules/data/aurora.tf
+++ b/terraform/modules/data/aurora.tf
@@ -6,9 +6,10 @@ module "aurora-metadata-db" {
 
   name = "${local.name}-${each.key}-metadata-db-${local.environment}"
 
-  engine         = "aurora-postgresql"
-  engine_version = each.value["engine_version"]
-  instance_type  = each.value["instance_type"]
+  engine             = "aurora-postgresql"
+  engine_version     = each.value["engine_version"]
+  instance_type      = each.value["instance_type"]
+  ca_cert_identifier = "rds-ca-rsa4096-g1"
 
   vpc_id                  = var.vpc_id
   subnets                 = data.aws_subnets.database.ids


### PR DESCRIPTION
* We are using v5.3.0 of the terraform-aws-modules/rds-aurora/aws module, which has the `ca_cert_identifier` variable defaulting to `rds-ca-2019`. This certificate expires on August 22nd, and doesn't support automatic certificate rotation.
* This changes the certificate identifier to `rds-ca-rsa4096-g1`, which will update to the latest CA, supporting automatic rotation.