### PR TITLE
Make Legislation integration test run against a canned version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v6.0.1 (2024-07-16)
 
+- Fix CI by reflecting changed output from legislation SPARQL output
+
 ### Refactor
 
 - **FCL-176**: explicitly set timezones to UTC

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --disable-socket --allow-hosts=127.0.0.1 --allow-hosts=localhost

--- a/scripts/test
+++ b/scripts/test
@@ -1,1 +1,1 @@
-pytest -m 'not integration' $*
+pytest $*

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -51,7 +51,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "6.0.0"
+    enrichment_version.string = "6.0.1"
 
     if not soup.proprietary:
         raise SourceXMLMissingElement("This document does not have a <proprietary> element.")

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
@@ -93,4 +93,68 @@ def test_fetch_legislation_integration(mock_datetime, set_env_vars) -> None:
         },
         index=[0, 0, 2, 2],
     )
+
+    assert result.equals(expected_df)
+
+
+@patch("update_legislation_table.fetch_legislation.SPARQLWrapper")
+def test_fetch_legislation_canned(mock_sparql_wrapper, set_env_vars) -> None:
+    """
+    GIVEN a set of environment variables including SPARQL_USERNAME and SPARQL_PASSWORD
+    WHEN fetch_legislation is called with a mocked date
+    THEN the resulting DataFrame should be as expected
+    """
+    # GIVEN
+    canned_sparql_response = b'"ref","title","ref_version","shorttitle","citation","acronymcitation","year"\n"http://www.legislation.gov.uk/id/ukpga/2023/10","UK Infrastructure Bank Act 2023","http://www.legislation.gov.uk/ukpga/2023/10","UK Infrastructure Bank Act 2023","2023 c. 10",,2023\n"http://www.legislation.gov.uk/id/ukpga/2023/10","UK Infrastructure Bank Act 2023","http://www.legislation.gov.uk/ukpga/2023/10/enacted","UK Infrastructure Bank Act 2023","2023 c. 10",,2023\n"http://www.legislation.gov.uk/id/ukpga/2023/8","Seafarers Wages Act 2023","http://www.legislation.gov.uk/ukpga/2023/8/enacted","Seafarers Wages Act 2023","2023 c. 8",,2023\n"http://www.legislation.gov.uk/id/ukpga/2023/8","Seafarers Wages Act 2023","http://www.legislation.gov.uk/ukpga/2023/8","Seafarers Wages Act 2023","2023 c. 8",,2023\n'
+    mock_sparql_wrapper.return_value.query.return_value.convert.return_value = canned_sparql_response
+
+    # WHEN
+    sparql_username = "tess_testerton"
+    sparql_password = "hunter2"  # noqa: S105
+
+    days = 16
+
+    result = fetch_legislation(sparql_username, sparql_password, days)
+
+    # THEN
+    expected_df = pd.DataFrame(
+        {
+            "ref": [
+                "http://www.legislation.gov.uk/id/ukpga/2023/10",
+                "http://www.legislation.gov.uk/id/ukpga/2023/10",
+                "http://www.legislation.gov.uk/id/ukpga/2023/8",
+                "http://www.legislation.gov.uk/id/ukpga/2023/8",
+            ],
+            "title": [
+                "UK Infrastructure Bank Act 2023",
+                "UK Infrastructure Bank Act 2023",
+                "Seafarers Wages Act 2023",
+                "Seafarers Wages Act 2023",
+            ],
+            "ref_version": [
+                "http://www.legislation.gov.uk/ukpga/2023/10",
+                "http://www.legislation.gov.uk/ukpga/2023/10",
+                "http://www.legislation.gov.uk/ukpga/2023/8/enacted",
+                "http://www.legislation.gov.uk/ukpga/2023/8/enacted",
+            ],
+            "shorttitle": [
+                "UK Infrastructure Bank Act 2023",
+                "UK Infrastructure Bank Act 2023",
+                "Seafarers Wages Act 2023",
+                "Seafarers Wages Act 2023",
+            ],
+            "citation": ["2023 c. 10", "2023 c. 10", "2023 c. 8", "2023 c. 8"],
+            "acronymcitation": [np.nan, np.nan, np.nan, np.nan],
+            "year": [2023, 2023, 2023, 2023],
+            "candidate_titles": [
+                "UK Infrastructure Bank Act 2023",
+                "2023 c. 10",
+                "Seafarers Wages Act 2023",
+                "2023 c. 8",
+            ],
+            "for_fuzzy": [True, False, True, False],
+        },
+        index=[0, 0, 2, 2],
+    )
+
     assert result.equals(expected_df)

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
@@ -1,19 +1,7 @@
-"""
-Integration test file for fetch_legislation module.
-
-Note that these tests require valid credentials for the SPARQL endpoint.
-The credentials should be stored in environment variables named
-'SPARQL_USERNAME' and 'SPARQL_PASSWORD'.
-"""
-
-import datetime
-import os
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import pytest
-from dotenv import load_dotenv
 
 from ..fetch_legislation import fetch_legislation
 
@@ -23,87 +11,8 @@ pd.set_option("display.max_columns", None)
 pd.set_option("display.max_colwidth", None)
 
 
-@pytest.fixture(scope="module")
-def set_env_vars():
-    load_dotenv()
-    yield
-    del os.environ["SPARQL_USERNAME"]
-    del os.environ["SPARQL_PASSWORD"]
-
-
-frozen_now_time = datetime.datetime(2023, 4, 13, 3, tzinfo=datetime.UTC)
-
-
-@pytest.mark.integration
-@patch("update_legislation_table.fetch_legislation.datetime.datetime")
-def test_fetch_legislation_integration(mock_datetime, set_env_vars) -> None:
-    """
-    GIVEN a set of environment variables including SPARQL_USERNAME and SPARQL_PASSWORD
-    WHEN fetch_legislation is called with a mocked date
-    THEN the resulting DataFrame should be as expected
-    """
-    # GIVEN
-    mock_datetime.now.return_value = frozen_now_time
-
-    # WHEN
-    sparql_username = os.environ.get("SPARQL_USERNAME", "")
-    sparql_password = os.environ.get("SPARQL_PASSWORD", "")
-
-    days = 16
-
-    result = fetch_legislation(sparql_username, sparql_password, days)
-
-    # THEN
-    expected_df = pd.DataFrame(
-        {
-            "ref": [
-                "http://www.legislation.gov.uk/id/ukpga/2023/10",
-                "http://www.legislation.gov.uk/id/ukpga/2023/10",
-                "http://www.legislation.gov.uk/id/ukpga/2023/8",
-                "http://www.legislation.gov.uk/id/ukpga/2023/8",
-            ],
-            "title": [
-                "UK Infrastructure Bank Act 2023",
-                "UK Infrastructure Bank Act 2023",
-                "Seafarers Wages Act 2023",
-                "Seafarers Wages Act 2023",
-            ],
-            "ref_version": [
-                "http://www.legislation.gov.uk/ukpga/2023/10",
-                "http://www.legislation.gov.uk/ukpga/2023/10",
-                "http://www.legislation.gov.uk/ukpga/2023/8/enacted",
-                "http://www.legislation.gov.uk/ukpga/2023/8/enacted",
-            ],
-            "shorttitle": [
-                "UK Infrastructure Bank Act 2023",
-                "UK Infrastructure Bank Act 2023",
-                "Seafarers Wages Act 2023",
-                "Seafarers Wages Act 2023",
-            ],
-            "citation": ["2023 c. 10", "2023 c. 10", "2023 c. 8", "2023 c. 8"],
-            "acronymcitation": [np.nan, np.nan, np.nan, np.nan],
-            "year": [2023, 2023, 2023, 2023],
-            "candidate_titles": [
-                "UK Infrastructure Bank Act 2023",
-                "2023 c. 10",
-                "Seafarers Wages Act 2023",
-                "2023 c. 8",
-            ],
-            "for_fuzzy": [True, False, True, False],
-        },
-        index=[0, 0, 2, 2],
-    )
-
-    assert result.equals(expected_df)
-
-
 @patch("update_legislation_table.fetch_legislation.SPARQLWrapper")
-def test_fetch_legislation_canned(mock_sparql_wrapper, set_env_vars) -> None:
-    """
-    GIVEN a set of environment variables including SPARQL_USERNAME and SPARQL_PASSWORD
-    WHEN fetch_legislation is called with a mocked date
-    THEN the resulting DataFrame should be as expected
-    """
+def test_fetch_legislation_canned(mock_sparql_wrapper) -> None:
     # GIVEN
     canned_sparql_response = b'"ref","title","ref_version","shorttitle","citation","acronymcitation","year"\n"http://www.legislation.gov.uk/id/ukpga/2023/10","UK Infrastructure Bank Act 2023","http://www.legislation.gov.uk/ukpga/2023/10","UK Infrastructure Bank Act 2023","2023 c. 10",,2023\n"http://www.legislation.gov.uk/id/ukpga/2023/10","UK Infrastructure Bank Act 2023","http://www.legislation.gov.uk/ukpga/2023/10/enacted","UK Infrastructure Bank Act 2023","2023 c. 10",,2023\n"http://www.legislation.gov.uk/id/ukpga/2023/8","Seafarers Wages Act 2023","http://www.legislation.gov.uk/ukpga/2023/8/enacted","Seafarers Wages Act 2023","2023 c. 8",,2023\n"http://www.legislation.gov.uk/id/ukpga/2023/8","Seafarers Wages Act 2023","http://www.legislation.gov.uk/ukpga/2023/8","Seafarers Wages Act 2023","2023 c. 8",,2023\n'
     mock_sparql_wrapper.return_value.query.return_value.convert.return_value = canned_sparql_response

--- a/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
+++ b/src/lambdas/update_legislation_table/update_legislation_table/tests/test_fetch_legislation.py
@@ -17,6 +17,11 @@ from dotenv import load_dotenv
 
 from ..fetch_legislation import fetch_legislation
 
+# Do not truncate debug output
+pd.set_option("display.max_rows", None)
+pd.set_option("display.max_columns", None)
+pd.set_option("display.max_colwidth", None)
+
 
 @pytest.fixture(scope="module")
 def set_env_vars():
@@ -52,37 +57,37 @@ def test_fetch_legislation_integration(mock_datetime, set_env_vars) -> None:
     expected_df = pd.DataFrame(
         {
             "ref": [
-                "http://www.legislation.gov.uk/id/ukpga/2023/8",
-                "http://www.legislation.gov.uk/id/ukpga/2023/8",
                 "http://www.legislation.gov.uk/id/ukpga/2023/10",
                 "http://www.legislation.gov.uk/id/ukpga/2023/10",
+                "http://www.legislation.gov.uk/id/ukpga/2023/8",
+                "http://www.legislation.gov.uk/id/ukpga/2023/8",
             ],
             "title": [
-                "Seafarers Wages Act 2023",
-                "Seafarers Wages Act 2023",
                 "UK Infrastructure Bank Act 2023",
                 "UK Infrastructure Bank Act 2023",
+                "Seafarers Wages Act 2023",
+                "Seafarers Wages Act 2023",
             ],
             "ref_version": [
+                "http://www.legislation.gov.uk/ukpga/2023/10",
+                "http://www.legislation.gov.uk/ukpga/2023/10",
                 "http://www.legislation.gov.uk/ukpga/2023/8/enacted",
                 "http://www.legislation.gov.uk/ukpga/2023/8/enacted",
-                "http://www.legislation.gov.uk/ukpga/2023/10/enacted",
-                "http://www.legislation.gov.uk/ukpga/2023/10/enacted",
             ],
             "shorttitle": [
-                "Seafarers Wages Act 2023",
-                "Seafarers Wages Act 2023",
                 "UK Infrastructure Bank Act 2023",
                 "UK Infrastructure Bank Act 2023",
+                "Seafarers Wages Act 2023",
+                "Seafarers Wages Act 2023",
             ],
-            "citation": ["2023 c. 8", "2023 c. 8", "2023 c. 10", "2023 c. 10"],
+            "citation": ["2023 c. 10", "2023 c. 10", "2023 c. 8", "2023 c. 8"],
             "acronymcitation": [np.nan, np.nan, np.nan, np.nan],
             "year": [2023, 2023, 2023, 2023],
             "candidate_titles": [
-                "Seafarers Wages Act 2023",
-                "2023 c. 8",
                 "UK Infrastructure Bank Act 2023",
                 "2023 c. 10",
+                "Seafarers Wages Act 2023",
+                "2023 c. 8",
             ],
             "for_fuzzy": [True, False, True, False],
         },

--- a/src/tests/replacer_tests/test_replacer_pipeline.py
+++ b/src/tests/replacer_tests/test_replacer_pipeline.py
@@ -107,6 +107,17 @@ class TestLegislationReplacer(unittest.TestCase):
         replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6/enacted" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>'
         assert replacement_string in replaced_entry
 
+    def test_citation_replacer_2_no_enacted(self):
+        legislation_match = "Children and Families Act 2014"  # matched legislation
+        href = "http://www.legislation.gov.uk/ukpga/2014/6"
+        text = "In her first judgment on 31 January, the judge correctly directed herself as to the law, reminding herself that any application for expert evidence in children’s proceedings is governed by s.13 of the Children and Families Act 2014."
+        canonical = "bar"
+        replacement_entry = (legislation_match, href, canonical)
+        replaced_entry = replacer_leg(text, replacement_entry)
+        assert legislation_match in replaced_entry
+        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>'
+        assert replacement_string in replaced_entry
+
 
 class TestReplacerAbbr(unittest.TestCase):
     """Unit Tests for `replacer_abbr`"""

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -20,3 +20,4 @@ rapidfuzz==3.9.4
 ds-caselaw-marklogic-api-client==24.0.0
 boto3-stubs[essential] ==1.34.145
 aws_lambda_powertools ==2.41.0
+pytest-socket==0.7.0


### PR DESCRIPTION
There was an assertion failing in `test_fetch_legislation.py::test_fetch_legislation_integration`. This connects to the Legislation SPARQL endpoint. It looks like the order of the rows returned has changed, and the URL returned is http://www.legislation.gov.uk/ukpga/2023/10 rather than http://www.legislation.gov.uk/ukpga/2023/10/enacted.

It's possible that this change of structure will impact the rest of enrichment, but it's not clear that it will. It's possible it's related to the issues we've been encountering with URLs recently. We've canned the response from legislation.

- \[x\] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- \[x\] Update CHANGELOG.md

https://national-archives.atlassian.net/browse/FCL-288