### PR TITLE
[FCL-138] Fix press summary urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.2 (2024-10-03)
+
+- Enrich press summaries by fixing patch url to be press-summary, not press/summary
+
 ## v6.0.1 (2024-07-16)
 
 - Fix CI by reflecting changed output from legislation SPARQL output

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 addopts = --disable-socket --allow-hosts=127.0.0.1 --allow-hosts=localhost
+env =
+    SOURCE_BUCKET=X
+    API_USERNAME=X
+    API_PASSWORD=X
+    ENVIRONMENT=X

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -49,7 +49,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "6.0.1"
+    enrichment_version.string = "6.0.2"
 
     if not soup.proprietary:
         msg = "This document does not have a <proprietary> element."

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -93,6 +93,7 @@ def process_event(sqs_rec: SQSRecord) -> None:
 
     print(source_key)
     judgment_uri = source_key.replace("-", "/").split(".")[0]
+    judgment_uri = judgment_uri.replace("press/summary", "press-summary")
     print(judgment_uri)
 
     # patch the judgment

--- a/src/tests/lambda_tests/push_enriched_xml/test_push_enriched_xml.py
+++ b/src/tests/lambda_tests/push_enriched_xml/test_push_enriched_xml.py
@@ -1,0 +1,28 @@
+# from lambdas.push_enriched_xml.index import (  # noqa: E402
+#     process_event,
+# )
+from unittest.mock import patch
+
+from lambdas.push_enriched_xml.index import (  # noqa: E402
+    process_event,
+)
+
+
+class FakeSQSRecord(dict):
+    def __init__(self):
+        self.body = '{"Validated": true}'
+        self["messageAttributes"] = {
+            "source_key": {"stringValue": "uksc/2024/1/press-summary/1"},
+            "source_bucket": {"stringValue": ""},
+        }
+        self["Validated"] = None
+
+
+@patch("lambdas.push_enriched_xml.index.boto3")
+@patch("lambdas.push_enriched_xml.index.requests")
+def test_patch_url_has_press_summary_with_a_hyphen(requests, boto3):
+    process_event(FakeSQSRecord())
+    assert (
+        requests.patch.call_args_list[0][0][0]
+        == "https://api.caselaw.nationalarchives.gov.uk/judgment/uksc/2024/1/press-summary/1"
+    )

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -21,3 +21,4 @@ ds-caselaw-marklogic-api-client==25.0.0
 boto3-stubs[essential] ==1.35.49
 aws_lambda_powertools ==3.2.0
 pytest-socket==0.7.0
+pytest-env==1.1.5


### PR DESCRIPTION
Enriched press summaries were being submitted to /judgment-url/press`/`summary/1?unlock=True, not press`-`summary.

We special case press-summary as a quick fix.

Added pytest-env as a test dependency to load environment variables -- patch.dict didn't seem to work.

<img width="746" alt="image" src="https://github.com/user-attachments/assets/7a03c1fa-f334-4574-9344-6a30adee1fbb">

- [x] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [x] Update CHANGELOG.md

https://national-archives.atlassian.net/browse/FCL-138