### PR TITLE
Revert "chore(deps): update public.ecr.aws/lambda/python docker tag to v3.13"

### DIFF
--- a/src/lambdas/db_backup/dockerfile
+++ b/src/lambdas/db_backup/dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 

--- a/src/lambdas/determine_legislation_provisions/Dockerfile
+++ b/src/lambdas/determine_legislation_provisions/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 # FROM public.ecr.aws/lambda/python:3.12
 # Using AWS lambda image for Python 3.6 that can use the pre-built postgress driver library
 # FROM lambci/lambda:build-python3.6

--- a/src/lambdas/determine_oblique_references/Dockerfile
+++ b/src/lambdas/determine_oblique_references/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 # Copy only the requirements file first and install dependencies
 COPY requirements.txt ${LAMBDA_TASK_ROOT}

--- a/src/lambdas/determine_replacements_abbreviations/Dockerfile
+++ b/src/lambdas/determine_replacements_abbreviations/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 # Set the timezone

--- a/src/lambdas/determine_replacements_caselaw/Dockerfile
+++ b/src/lambdas/determine_replacements_caselaw/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 # Set the timezone

--- a/src/lambdas/determine_replacements_legislation/Dockerfile
+++ b/src/lambdas/determine_replacements_legislation/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 # Set the timezone

--- a/src/lambdas/fetch_xml/dockerfile
+++ b/src/lambdas/fetch_xml/dockerfile
@@ -13,7 +13,7 @@
 
 ### TRY THIS CODE INSTEAD
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 

--- a/src/lambdas/push_enriched_xml/dockerfile
+++ b/src/lambdas/push_enriched_xml/dockerfile
@@ -13,7 +13,7 @@
 
 ### TRY THIS CODE INSTEAD
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 COPY index.py ${LAMBDA_TASK_ROOT}
 

--- a/src/lambdas/update_legislation_table/Dockerfile
+++ b/src/lambdas/update_legislation_table/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
 

--- a/src/lambdas/update_rules_processor/Dockerfile
+++ b/src/lambdas/update_rules_processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.12
 
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
 


### PR DESCRIPTION
Reverts nationalarchives/ds-caselaw-data-enrichment-service#635

There appear to be no compilers in this docker image, so numpy cannot be built from source. (Possibly due to the lack of a 3.13 compatible binary?)

```
#11 [7/7] RUN pip install -r requirements.txt --target "/var/task"
#11 0.617 Collecting numpy==1.26.4 (from -r requirements.txt (line 2))
#11 0.649   Downloading numpy-1.26.4.tar.gz (15.8 MB)
#11 0.788      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.8/15.8 MB 133.6 MB/s eta 0:00:00
#11 3.062   Installing build dependencies: started
#11 5.504   Installing build dependencies: finished with status 'done'
#11 5.506   Getting requirements to build wheel: started
#11 5.614   Getting requirements to build wheel: finished with status 'done'
#11 5.617   Installing backend dependencies: started
#11 6.372   Installing backend dependencies: finished with status 'done'
#11 6.373   Preparing metadata (pyproject.toml): started
#11 7.384   Preparing metadata (pyproject.toml): finished with status 'error'
#11 7.388   error: subprocess-exited-with-error
#11 7.388   
#11 7.388   × Preparing metadata (pyproject.toml) did not run successfully.
#11 7.388   │ exit code: 1
#11 7.388   ╰─> [20 lines of output]
#11 7.388       + /var/lang/bin/python3.13 /tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7/vendored-meson/meson/meson.py setup /tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7 /tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7/.mesonpy-7ihg2j7u -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7/.mesonpy-7ihg2j7u/meson-python-native-file.ini
#11 7.388       The Meson build system
#11 7.388       Version: 1.2.99
#11 7.388       Source dir: /tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7
#11 7.388       Build dir: /tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7/.mesonpy-7ihg2j7u
#11 7.388       Build type: native build
#11 7.388       Project name: NumPy
#11 7.388       Project version: 1.26.4
#11 7.388       
#11 7.388       ../meson.build:1:0: ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ['nvc'], ['pgcc'], ['icc'], ['icx']]
#11 7.388       The following exception(s) were encountered:
#11 7.388       Running `cc --version` gave "[Errno 2] No such file or directory: 'cc'"
#11 7.388       Running `gcc --version` gave "[Errno 2] No such file or directory: 'gcc'"
#11 7.388       Running `clang --version` gave "[Errno 2] No such file or directory: 'clang'"
#11 7.388       Running `nvc --version` gave "[Errno 2] No such file or directory: 'nvc'"
#11 7.388       Running `pgcc --version` gave "[Errno 2] No such file or directory: 'pgcc'"
#11 7.388       Running `icc --version` gave "[Errno 2] No such file or directory: 'icc'"
#11 7.388       Running `icx --version` gave "[Errno 2] No such file or directory: 'icx'"
#11 7.388       
#11 7.388       A full log can be found at /tmp/pip-install-1c8i_hbs/numpy_c59302ab73de497c803abaa84f34c9f7/.mesonpy-7ihg2j7u/meson-logs/meson-log.txt
#11 7.388       [end of output]
```