### PR TITLE
Use ubuntu-22.04 for some github actions: 24 broke some environment variables

### DIFF
--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-pre-commit:
     name: Run pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
 
   run-tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.2.2
@@ -54,7 +54,7 @@ jobs:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
 
   terraform_format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout source code
@@ -76,7 +76,7 @@ jobs:
         continue-on-error: false
 
   terraform_lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout source code
@@ -97,7 +97,7 @@ jobs:
           tflint -f compact --loglevel warn
 
   terraform_validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout source code
@@ -129,7 +129,7 @@ jobs:
 
   tfsec-pr-commenter:
     name: tfsec PR commenter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   terraform_plan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

A version bump PR was encountering issues with Code Climate and Terraform not receiving critical environment variables. An ongoing github update of ubuntu-latest to ubuntu-22.04 seems to have caused this issue. We pin to ubuntu-22.04 in the hopes that tooling is fixed upstream in the next two years; pinning to ubuntu-22 seems to have fixed the issue.
![image](https://github.com/user-attachments/assets/df8e128e-9044-4120-ab14-ee2fe18c0dd1)

![image](https://github.com/user-attachments/assets/b27de39d-b4ba-4541-9ef8-880a07ec4418)
![image](https://github.com/user-attachments/assets/e1f559ff-c41e-4d5d-ba71-44199bddb6d0)


### Jira card / Rollbar error (etc)

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
