### PR TITLE
Use zizmor as a static ci linter

### DIFF
--- a/.github/workflows/cd_deploy_staging_then_prod.yml
+++ b/.github/workflows/cd_deploy_staging_then_prod.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   pull-requests: read
-  id-token: write
   contents: read
 
 defaults:
@@ -23,6 +22,8 @@ jobs:
       account_id: ${{ secrets.STAGING_ACCOUNT_ID }}
       workspace: tna-staging
       app_env: staging
+    permissions:
+      id-token: write
 
   deploy_production:
     name: Deploy Production Build
@@ -33,3 +34,5 @@ jobs:
       account_id: ${{ secrets.PROD_ACCOUNT_ID }}
       workspace: tna-prod
       app_env: production
+    permissions:
+      id-token: write

--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -1,5 +1,5 @@
 name: ci_lint_and_test
-
+permissions: {}
 on:
   pull_request:
     branches: [main]
@@ -18,6 +18,8 @@ jobs:
 
       - name: Checkout Code Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
@@ -32,6 +34,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5.4.0
@@ -65,6 +68,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3.1.2
@@ -87,6 +91,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Install TFLint
         uses: terraform-linters/setup-tflint@v4.1.1
@@ -108,6 +113,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Get terraform version
         id: get-terraform-version
@@ -140,7 +146,8 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: tfsec
         uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:

--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -156,6 +156,9 @@ jobs:
 
   terraform_plan-staging:
     uses: ./.github/workflows/terraform_plan.yml
+    permissions:
+      contents: read
+      id-token: write
     secrets:
       aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       account_id: ${{ secrets.STAGING_ACCOUNT_ID }}
@@ -164,6 +167,9 @@ jobs:
 
   terraform_plan-production:
     uses: ./.github/workflows/terraform_plan.yml
+    permissions:
+      contents: read
+      id-token: write
     secrets:
       aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN_PROD }}
       account_id: ${{ secrets.PROD_ACCOUNT_ID }}

--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5.4.0

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Get terraform version
         id: get-terraform-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,8 @@ repos:
       - id: prettier
         types_or: [yaml, json, xml, markdown, scss, javascript]
         exclude: "terraform/README.md"
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.5.1
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
<!-- Amend as appropriate -->

This one has a warning about too much permissions -- both subtasks almost certainly need it, but this makes zizmor happy.

## Changes in this PR:

### Jira card / Rollbar error (etc)

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
