### PR TITLE
Add terraform permissions

### DIFF
--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -149,6 +149,9 @@ jobs:
 
   terraform_plan-staging:
     uses: ./.github/workflows/terraform_plan.yml
+    permissions:
+      contents: read
+      id-token: write
     secrets:
       aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       account_id: ${{ secrets.STAGING_ACCOUNT_ID }}
@@ -157,6 +160,9 @@ jobs:
 
   terraform_plan-production:
     uses: ./.github/workflows/terraform_plan.yml
+    permissions:
+      contents: read
+      id-token: write
     secrets:
       aws_oidc_role_arn: ${{ secrets.AWS_OIDC_ROLE_ARN_PROD }}
       account_id: ${{ secrets.PROD_ACCOUNT_ID }}


### PR DESCRIPTION
After following zizmor suggestions, some workflows don't work:

Invalid workflow file: .github/workflows/ci_lint_and_test.yml#L157
The workflow is not valid. .github/workflows/ci_lint_and_test.yml (Line: 157, Col: 3): Error calling workflow 'nationalarchives/ds-caselaw-data-enrichment-service/.github/workflows/terraform_plan.yml@cee2ad07429cfe6599f0f894cc84199fd236b69f'. The nested job 'terraform_plan' is requesting 'contents: read, id-token: write', but is only allowed 'contents: none, id-token: none'.

## Changes in this PR:

### Jira card / Rollbar error (etc)

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
