### PR TITLE
Fix replace_string_with_tag for when the xml fragment string includes uk namespace attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.0.1 (2025-05-19)
+
+- Fix replace_string_with_tag for when the xml fragment string includes uk namespace attributes
+
 ## v7.0.0 (2024-11-28)
 
 - Ensure that documents with matching replacements don't replace inside XML strings

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -49,7 +49,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "7.0.0"
+    enrichment_version.string = "7.0.1"
 
     if not soup.proprietary:
         msg = "This document does not have a <proprietary> element."

--- a/src/tests/replacer_tests/test_make_replacements.py
+++ b/src/tests/replacer_tests/test_make_replacements.py
@@ -53,13 +53,8 @@ class TestMakePostHeaderReplacements:
         {"case": ["a", "b", "2008", "#", true]}
         {"case": ["b", "c", "1937", "#", true]}
         """.strip()
-        expected_file_content = """<?xml version="1.0" encoding="utf-8"?>
-        <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
-        <judgment name="judgment"><header/><judgmentBody>
-        <ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="b" uk:year="2008" uk:origin="TNA">a</ref>
-        </judgmentBody></judgment></akomaNtoso>"""
-        content_with_replacements = make_post_header_replacements(original_file_content, replacement_content)
-        assert_equal_xml(content_with_replacements, expected_file_content)
+        expected_file_content = '<?xml version="1.0" encoding="utf-8"?>\n<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"><judgment name="judgment"><header/><judgmentBody><ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="b" uk:year="2008" uk:origin="TNA">a</ref></judgmentBody></judgment></akomaNtoso>'
+        assert make_post_header_replacements(original_file_content, replacement_content) == expected_file_content
 
     def test_remove_nested_legislation_references(self):
         tidy_output = _remove_old_enrichment_references(

--- a/src/tests/replacer_tests/test_replacer_pipeline.py
+++ b/src/tests/replacer_tests/test_replacer_pipeline.py
@@ -17,27 +17,27 @@ class TestCitationReplacer(unittest.TestCase):
         citation_match = "[2025] 1 All E.R. 123"  # incorrect citation
         corrected_citation = "[2025] 1 All ER 123"  # in practice, returned via the citation matcher
         year = "2025"
-        URI = "#"
+        uri = "#"
         is_neutral = "true"
-        text = "<z>In the judgment the incorrect citation is [2025] 1 All E.R. 123.</z>"
-        replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
-        replaced_entry = replacer_caselaw(text, replacement_entry)
-        assert corrected_citation in replaced_entry
-        replacement_string = f'<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:year="{year}" uk:origin="TNA">{citation_match}</ref>'
-        assert replacement_string in replaced_entry
+        text = "<z>In the judgment the incorrect citation is [2025] 1 All E.R. 123. <table uk:widths='1.38in 1.05in 0.91in 0.98in 0.98in 0.95in'></table></z>"
+        replacement_entry = (citation_match, corrected_citation, year, uri, is_neutral)
+        assert (
+            replacer_caselaw(text, replacement_entry)
+            == '<z>In the judgment the incorrect citation is <ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="[2025] 1 All ER 123" uk:year="2025" uk:origin="TNA">[2025] 1 All E.R. 123</ref>. <table uk:widths="1.38in 1.05in 0.91in 0.98in 0.98in 0.95in"/></z>'
+        )
 
     def test_citation_replacer_2(self):
         citation_match = "[2022] UKET 789123_2012"
         corrected_citation = "[2022] UKET 789123/2012"
         year = "2022"
-        URI = "#"
+        uri = "#"
         is_neutral = "true"
         text = "<z>This citation that needs to be changed is [2022] UKET 789123_2012 which discussed...</z>"
-        replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
-        replaced_entry = replacer_caselaw(text, replacement_entry)
-        assert corrected_citation in replaced_entry
-        replacement_string = f'<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:year="{year}" uk:origin="TNA">{citation_match}</ref>'
-        assert replacement_string in replaced_entry
+        replacement_entry = (citation_match, corrected_citation, year, uri, is_neutral)
+        assert (
+            replacer_caselaw(text, replacement_entry)
+            == '<z>This citation that needs to be changed is <ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="[2022] UKET 789123/2012" uk:year="2022" uk:origin="TNA">[2022] UKET 789123_2012</ref> which discussed...</z>'
+        )
 
     def test_citation_replacer_3_no_year(self):
         """Note that this test does not have a year, so there is no uk:year attribute, unlike the others"""
@@ -45,39 +45,39 @@ class TestCitationReplacer(unittest.TestCase):
         corrected_citation = "LR 1 AE 123"
         year = "No Year"
         text = "<z>LR 1 A&amp;E 123 refers to...</z>"
-        URI = "#"
+        uri = "#"
         is_neutral = "true"
-        replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
-        replaced_entry = replacer_caselaw(text, replacement_entry)
-        assert corrected_citation in replaced_entry
-        replacement_string = f'<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:origin="TNA">LR 1 A&amp;E 123</ref>'
-        assert replacement_string in replaced_entry
+        replacement_entry = (citation_match, corrected_citation, year, uri, is_neutral)
+        assert (
+            replacer_caselaw(text, replacement_entry)
+            == '<z><ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="LR 1 AE 123" uk:origin="TNA">LR 1 A&amp;E 123</ref> refers to...</z>'
+        )
 
     def test_citation_replacer_4(self):
         citation_match = "(2022) EWHC 123 (Mercantile)"
         corrected_citation = "[2022] EWHC 123 (Mercantile)"
         year = "2022"
-        URI = "#"
+        uri = "#"
         is_neutral = "true"
         text = "<z>I defer to the judgment in (2022) EWHC 123 (Mercantile).</z>"
-        replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
-        replaced_entry = replacer_caselaw(text, replacement_entry)
-        assert corrected_citation in replaced_entry
-        replacement_string = f'<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:year="{year}" uk:origin="TNA">{citation_match}</ref>'
-        assert replacement_string in replaced_entry
+        replacement_entry = (citation_match, corrected_citation, year, uri, is_neutral)
+        assert (
+            replacer_caselaw(text, replacement_entry)
+            == '<z>I defer to the judgment in <ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="[2022] EWHC 123 (Mercantile)" uk:year="2022" uk:origin="TNA">(2022) EWHC 123 (Mercantile)</ref>.</z>'
+        )
 
     def test_citation_replacer_5(self):
         citation_match = "[2022] ewca civ 123"
         corrected_citation = "[2022] EWCA Civ 123"
         year = "2022"
-        URI = "#"
+        uri = "#"
         is_neutral = "true"
         text = "<z>[2022] ewca civ 123.</z>"
-        replacement_entry = (citation_match, corrected_citation, year, URI, is_neutral)
-        replaced_entry = replacer_caselaw(text, replacement_entry)
-        assert corrected_citation in replaced_entry
-        replacement_string = f'<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="{URI}" uk:isNeutral="{is_neutral}" uk:canonical="{corrected_citation}" uk:year="{year}" uk:origin="TNA">{citation_match}</ref>'
-        assert replacement_string in replaced_entry
+        replacement_entry = (citation_match, corrected_citation, year, uri, is_neutral)
+        assert (
+            replacer_caselaw(text, replacement_entry)
+            == '<z><ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="case" href="#" uk:isNeutral="true" uk:canonical="[2022] EWCA Civ 123" uk:year="2022" uk:origin="TNA">[2022] ewca civ 123</ref>.</z>'
+        )
 
 
 class TestLegislationReplacer(unittest.TestCase):
@@ -91,10 +91,10 @@ class TestLegislationReplacer(unittest.TestCase):
         text = "<z>In their skeleton argument in support of the first ground, Mr Goodwin and Mr Redmond remind the court that the welfare checklist in s.1(4) of the Adoption and Children Act 2002 requires the court, inter alia</z>"
         canonical = "foo"
         replacement_entry = (legislation_match, href, canonical)
-        replaced_entry = replacer_leg(text, replacement_entry)
-        assert legislation_match in replaced_entry
-        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2002/38" uk:canonical="foo" uk:origin="TNA">Adoption and Children Act 2002</ref>'
-        assert replacement_string in replaced_entry
+        assert (
+            replacer_leg(text, replacement_entry)
+            == '<z>In their skeleton argument in support of the first ground, Mr Goodwin and Mr Redmond remind the court that the welfare checklist in s.1(4) of the <ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2002/38" uk:canonical="foo" uk:origin="TNA">Adoption and Children Act 2002</ref> requires the court, inter alia</z>'
+        )
 
     def test_citation_replacer_2(self):
         legislation_match = "Children and Families Act 2014"  # matched legislation
@@ -102,10 +102,10 @@ class TestLegislationReplacer(unittest.TestCase):
         text = "<z>In her first judgment on 31 January, the judge correctly directed herself as to the law, reminding herself that any application for expert evidence in children’s proceedings is governed by s.13 of the Children and Families Act 2014.</z>"
         canonical = "bar"
         replacement_entry = (legislation_match, href, canonical)
-        replaced_entry = replacer_leg(text, replacement_entry)
-        assert legislation_match in replaced_entry
-        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6/enacted" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>'
-        assert replacement_string in replaced_entry
+        assert (
+            replacer_leg(text, replacement_entry)
+            == '<z>In her first judgment on 31 January, the judge correctly directed herself as to the law, reminding herself that any application for expert evidence in children&#8217;s proceedings is governed by s.13 of the <ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6/enacted" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>.</z>'
+        )
 
     def test_citation_replacer_2_no_enacted(self):
         legislation_match = "Children and Families Act 2014"  # matched legislation
@@ -113,10 +113,10 @@ class TestLegislationReplacer(unittest.TestCase):
         text = "<z>In her first judgment on 31 January, the judge correctly directed herself as to the law, reminding herself that any application for expert evidence in children’s proceedings is governed by s.13 of the Children and Families Act 2014.</z>"
         canonical = "bar"
         replacement_entry = (legislation_match, href, canonical)
-        replaced_entry = replacer_leg(text, replacement_entry)
-        assert legislation_match in replaced_entry
-        replacement_string = '<ref xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>'
-        assert replacement_string in replaced_entry
+        assert (
+            replacer_leg(text, replacement_entry)
+            == '<z>In her first judgment on 31 January, the judge correctly directed herself as to the law, reminding herself that any application for expert evidence in children&#8217;s proceedings is governed by s.13 of the <ref xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" uk:type="legislation" href="http://www.legislation.gov.uk/ukpga/2014/6" uk:canonical="bar" uk:origin="TNA">Children and Families Act 2014</ref>.</z>'
+        )
 
 
 class TestReplacerAbbr(unittest.TestCase):

--- a/src/utils/tests/test_proper_xml.py
+++ b/src/utils/tests/test_proper_xml.py
@@ -5,6 +5,22 @@ from utils.proper_xml import create_tag_string, replace_string_with_tag
 
 
 class TestReplaceStringWithTag:
+    def test_when_includes_uk_namespace_attributes(self):
+        """
+        Given an XML fragment containing uk: attributes on an element (e.g., <table>),
+        And a string to search for (e.g., "a"),
+        And a replacement string (e.g., <ref uk:type="case">a</ref>),
+        When replace_string_with_tag is called,
+        Then the XML fragment should be modified to include the replacement string
+        """
+        input_xml = '<judgmentBody><table uk:widths="1.38in">a</table></judgmentBody>'
+        search = "a"
+        replacement = '<ref uk:type="case">a</ref>'
+        expected = '<judgmentBody><table uk:widths="1.38in"><ref uk:type="case">a</ref></table></judgmentBody>'
+
+        result = replace_string_with_tag(input_xml, search, replacement)
+        assert result == expected
+
     def test_as_text(self):
         assert_equal_xml(
             replace_string_with_tag("<p>In [2024] UKSC 1 ...</p>", "[2024] UKSC 1", "<ref blah='blah'>blah</ref>"),


### PR DESCRIPTION
# Changes in this PR:

Fix replace_string_with_tag for when the xml fragment string includes uk namespace attributes

Don't love my current fix but I think the whole thing needs a rethink, but this should suffice for now

### Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FDD-35

- [x] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [x] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
