### PR TITLE
Fix push_enriched_xml by stripping the .xml suffix from the specified uri when patching the doc in the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2.1 (2025-06-27)
+
+- Fixed push_enriched_xml by stripping the .xml suffix from the specified uri when patching the doc in the database
+
 ## v7.2.0 (2025-06-27)
 
 - Stopped replacing hyphens with slashes from the original document database uri when storing the xml in s3 as it causes issue for documents with hyphens in the uri when trying to reverse the process when pushing back to judgment database.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts = --disable-socket --allow-hosts=127.0.0.1 --allow-hosts=localhost
 env =
-    SOURCE_BUCKET=X
-    API_USERNAME=X
-    API_PASSWORD=X
-    ENVIRONMENT=X
+    SOURCE_BUCKET=TEST_SOURCE_BUCKET
+    API_USERNAME=TEST_USERNAME
+    API_PASSWORD=TEST_PASSWORD
+    ENVIRONMENT=TEST_ENVIRONMENT

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -47,7 +47,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "7.2.0"
+    enrichment_version.string = "7.2.1"
 
     if not soup.proprietary:
         msg = "This document does not have a <proprietary> element."

--- a/src/tests/lambda_tests/push_enriched_xml/test_push_enriched_xml.py
+++ b/src/tests/lambda_tests/push_enriched_xml/test_push_enriched_xml.py
@@ -1,28 +1,53 @@
-# from lambdas.push_enriched_xml.index import (  # noqa: E402
-#     process_event,
-# )
 from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+from requests.auth import HTTPBasicAuth
 
 from lambdas.push_enriched_xml.index import (  # noqa: E402
     process_event,
 )
 
 
-class FakeSQSRecord(dict):
-    def __init__(self):
-        self.body = '{"Validated": true}'
-        self["messageAttributes"] = {
-            "source_key": {"stringValue": "uksc/2024/1/press-summary/1"},
-            "source_bucket": {"stringValue": ""},
-        }
-        self["Validated"] = None
-
-
-@patch("lambdas.push_enriched_xml.index.boto3")
+@pytest.mark.parametrize(
+    "source_key_prefix",
+    ["uksc/2024/1", "d-d911a2bd-72ef-44ab-8bbb-dfd1b632dded/press-summary/1"],
+)
+@mock_aws
 @patch("lambdas.push_enriched_xml.index.requests")
-def test_patch_url_has_press_summary_with_a_hyphen(requests, boto3):
+def test_push_enriched_xml(requests_mock, monkeypatch, source_key_prefix):
+    """
+    Given a SQS record for a XML file in S3 with .xml suffix,
+    When process_event function is called with it
+    Then it fetches XML content from S3, and sends a PATCH request to the API endpoint
+    for the URI corresponding to the XML file, with the XML content as the body.
+    """
+
+    # Setup mock S3
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="test_bucket")
+    s3.put_object(Bucket="test_bucket", Key=f"{source_key_prefix}.xml", Body="<xml>Enriched content</xml>")
+
+    class FakeSQSRecord(dict):
+        def __init__(self):
+            self.body = '{"Validated": true}'
+            self["messageAttributes"] = {
+                "source_key": {"stringValue": f"{source_key_prefix}.xml"},
+                "source_bucket": {"stringValue": "test_bucket"},
+            }
+
     process_event(FakeSQSRecord())
+
+    # Assert that the requests.patch method was called with the correct data
+    requests_mock.patch.assert_called_once()
+    args, kwargs = requests_mock.patch.call_args
+    assert kwargs["data"] == b"<xml>Enriched content</xml>"
+    assert kwargs["params"] == {"unlock": True}
+    assert isinstance(kwargs["auth"], HTTPBasicAuth)
     assert (
-        requests.patch.call_args_list[0][0][0]
-        == "https://api.caselaw.nationalarchives.gov.uk/judgment/uksc/2024/1/press-summary/1"
-    )
+        kwargs["auth"].username == "TEST_USERNAME"
+    )  # come from pytest.ini, should change this but will break other tests, without setting env vars for each, so will leave for now
+    assert kwargs["auth"].password == "TEST_PASSWORD"  # noqa: S105
+    assert kwargs["timeout"] == 10
+    assert args[0] == f"https://api.caselaw.nationalarchives.gov.uk/judgment/{source_key_prefix}"


### PR DESCRIPTION
## Changes in this PR:

Fix push_enriched_xml by stripping the .xml suffix from the specified uri when patching the doc in the database

### Jira card / Rollbar error (etc)

- [x] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [x] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
