### PR TITLE
Canonicalize final stag enriched xml before writing back to marklogic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2.2 (2025-06-30)
+
+- Fixed push_enriched_xml by stripping canonicalizing the xml stored in the final stage enrichment s3 bucket before sending it to the privileged api.
+
 ## v7.2.1 (2025-06-27)
 
 - Fixed push_enriched_xml by stripping the .xml suffix from the specified uri when patching the doc in the database

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -47,7 +47,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "7.2.1"
+    enrichment_version.string = "7.2.2"
 
     if not soup.proprietary:
         msg = "This document does not have a <proprietary> element."

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -7,6 +7,7 @@ import urllib3
 from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from lxml import etree
 from requests.auth import HTTPBasicAuth
 
 from utils.custom_types import APIEndpointBaseURL, DocumentAsXMLString
@@ -97,13 +98,14 @@ def process_event(sqs_rec: SQSRecord) -> None:
     file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"].read().decode("utf-8"),
     )
+    canonical_xml = etree.canonicalize(file_content)
 
     document_uri = source_key.replace(".xml", "")
     LOGGER.info("Document URI from message")
     LOGGER.info(document_uri)
 
     # patch the judgment
-    patch_judgment_request(api_endpoint, document_uri, file_content, API_USERNAME, API_PASSWORD)
+    patch_judgment_request(api_endpoint, document_uri, canonical_xml, API_USERNAME, API_PASSWORD)
 
 
 ############################################


### PR DESCRIPTION
## Changes in this PR:

Canonicalize final stage enriched xml before writing back to marklogic.

Not ideal that we are storing invalid/ non canonical xml in s3 in the pipeline but this should get it working for now. We already want to go through and reduce the number of lambdas and potentially s3 buckets so don't want to get into the nitty gritty just yet.

### Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FDD-59

- [x] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [x] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
