### PR TITLE
Add lxml as a dependency for the push_enriched_xml lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2.3 (2025-06-30)
+
+- Add `lxml` as a dependency for the `push_enriched_xml` lambda
+
 ## v7.2.2 (2025-06-30)
 
 - Fixed push_enriched_xml by stripping canonicalizing the xml stored in the final stage enrichment s3 bucket before sending it to the privileged api.

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -47,7 +47,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "7.2.2"
+    enrichment_version.string = "7.2.3"
 
     if not soup.proprietary:
         msg = "This document does not have a <proprietary> element."

--- a/src/lambdas/push_enriched_xml/requirements.txt
+++ b/src/lambdas/push_enriched_xml/requirements.txt
@@ -2,3 +2,4 @@ requests==2.32.4
 boto3==1.38.46
 botocore==1.38.46
 aws_lambda_powertools==3.15.1
+lxml==5.4.0


### PR DESCRIPTION
## Changes in this PR:

Add lxml as a dependency for the push_enriched_xml lambda

Wasn't caught in CI as we install all the deps and then run the tests for each lambda and most of the other lambdas have this as a dep.

### Jira card / Rollbar error (etc)

- [x] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [x] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
