### PR TITLE
Fully canonicalise final stage enriched xml before writing back to marklogic and bump to version 7.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## v7.2.2 (2025-06-30)
+
+- Fixed push_enriched_xml by fully canonicalizing the xml stored in the final stage enrichment s3 bucket before sending it to the privileged api.
+
 ## v7.2.3 (2025-06-30)
 
 - Add `lxml` as a dependency for the `push_enriched_xml` lambda
 
 ## v7.2.2 (2025-06-30)
 
-- Fixed push_enriched_xml by stripping canonicalizing the xml stored in the final stage enrichment s3 bucket before sending it to the privileged api.
+- Fixed push_enriched_xml by canonicalizing the xml stored in the final stage enrichment s3 bucket before sending it to the privileged api.
 
 ## v7.2.1 (2025-06-27)
 

--- a/src/lambdas/determine_legislation_provisions/index.py
+++ b/src/lambdas/determine_legislation_provisions/index.py
@@ -47,7 +47,7 @@ def add_timestamp_and_engine_version(
         "uk:tna-enrichment-engine",
         attrs={"xmlns:uk": "https://caselaw.nationalarchives.gov.uk/akn"},
     )
-    enrichment_version.string = "7.2.3"
+    enrichment_version.string = "7.2.4"
 
     if not soup.proprietary:
         msg = "This document does not have a <proprietary> element."

--- a/src/lambdas/push_enriched_xml/index.py
+++ b/src/lambdas/push_enriched_xml/index.py
@@ -98,7 +98,9 @@ def process_event(sqs_rec: SQSRecord) -> None:
     file_content = DocumentAsXMLString(
         s3_client.get_object(Bucket=source_bucket, Key=source_key)["Body"].read().decode("utf-8"),
     )
-    canonical_xml = etree.canonicalize(file_content)
+    # Canonicalize using lxml.etree.tostring with method="c14n"
+    tree = etree.fromstring(file_content)
+    canonical_xml = etree.tostring(tree, method="c14n").decode("utf-8")
 
     document_uri = source_key.replace(".xml", "")
     LOGGER.info("Document URI from message")

--- a/src/tests/lambda_tests/push_enriched_xml/test_push_enriched_xml.py
+++ b/src/tests/lambda_tests/push_enriched_xml/test_push_enriched_xml.py
@@ -29,9 +29,24 @@ def test_push_enriched_xml(requests_mock, monkeypatch, source_key_prefix):
     s3.create_bucket(Bucket="test_bucket")
 
     # Non-canonical XML: redundant xmlns on child
-    non_canonical_xml = (
-        '<root xmlns="urn:foo"><child xmlns="urn:foo">text</child><child2 xmlns="urn:foo">more</child2></root>'
-    )
+    non_canonical_xml = """<?xml version="1.0"?>
+    <!-- Outer comment -->
+    <root xmlns="urn:foo" xmlns:bar="urn:bar" attr2="2" attr1="1">
+        <parent attr="p1" xmlns:bar="urn:bar">
+            <child1 bar:attr="b1" attr="c1" xmlns="urn:foo" xmlns:bar="urn:bar">
+                <subchild attr="s1" bar:attr="sb1">
+                    <!-- Nested comment -->
+                    <?pi nested processing instruction?>
+                    value
+                </subchild>
+            </child1>
+            <child2 attr="c2" xmlns="urn:foo">
+                <subchild2 attr="s2"/>
+            </child2>
+        </parent>
+        <emptychild xmlns="urn:foo" />
+    </root>
+    """
     s3.put_object(Bucket="test_bucket", Key=f"{source_key_prefix}.xml", Body=non_canonical_xml)
 
     class FakeSQSRecord(dict):
@@ -47,7 +62,13 @@ def test_push_enriched_xml(requests_mock, monkeypatch, source_key_prefix):
     # Assert that the requests.patch method was called with the correct data
     requests_mock.patch.assert_called_once()
     args, kwargs = requests_mock.patch.call_args
-    assert kwargs["data"] == b'<root xmlns="urn:foo"><child>text</child><child2>more</child2></root>'
+    expected_canonical = (
+        b'<root xmlns="urn:foo" attr1="1" attr2="2">'
+        b'<child bar:attr="barvalue" attr="value" xmlns:bar="urn:bar">text</child>'
+        b'<child2 attr="another" attr2="second"/>'
+        b"</root>"
+    )
+    assert kwargs["data"] == expected_canonical
     assert kwargs["params"] == {"unlock": True}
     assert isinstance(kwargs["auth"], HTTPBasicAuth)
     assert (


### PR DESCRIPTION
## Changes in this PR:

Fully canonicalise final stage enriched xml before writing back to marklogic and bump to version 7.2.4

### Jira card / Rollbar error (etc)

- [x] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [x] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
