### PR TITLE
Allow renovate to automerge dockerfile digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
-  "ignorePaths": []
+  "ignorePaths": [],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true,
+    }
+  ]
 }


### PR DESCRIPTION
## Changes in this PR:

Allow renovate to automerge dockerfile digest updates

E.g. https://github.com/nationalarchives/ds-caselaw-data-enrichment-service/pull/1072/files

Once this is merged in, to test, I will close https://github.com/nationalarchives/ds-caselaw-data-enrichment-service/pull/1072/files and then wait for renovate to recreate and see if it automerges

### Jira card / Rollbar error (etc)

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
