### PR TITLE
Swap in codecov to replace codeclimate

### DIFF
--- a/.github/workflows/ci_lint_and_test.yml
+++ b/.github/workflows/ci_lint_and_test.yml
@@ -49,16 +49,12 @@ jobs:
         env:
           SPARQL_USERNAME: ${{ secrets.SPARQL_USERNAME }}
           SPARQL_PASSWORD: ${{ secrets.SPARQL_PASSWORD }}
-        id: run_python_tests
-        run: coverage run --source . -m pytest
+        run: pytest -rsax -vvvv --cov --cov-branch --cov-report=xml
 
-      - name: Generate coverage XML
-        run: coverage xml
-
-      - name: Upload coverage to CodeClimate
-        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   terraform_format:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository is part of the [Find Case Law](https://caselaw.nationalarchives.
 
 # Judgment Enrichment Pipeline
 
-![Tests](https://img.shields.io/github/actions/workflow/status/nationalarchives/ds-caselaw-data-enrichment-service/ci_lint_and_test.yml?branch=main&label=tests) ![Coverage](https://img.shields.io/codeclimate/coverage/nationalarchives/ds-caselaw-data-enrichment-service) ![Maintainability](https://img.shields.io/codeclimate/maintainability/nationalarchives/ds-caselaw-data-enrichment-service)
+![Tests](https://img.shields.io/github/actions/workflow/status/nationalarchives/ds-caselaw-data-enrichment-service/ci_lint_and_test.yml?branch=main&label=tests)
+![Code Coverage](https://img.shields.io/codecov/c/github/nationalarchives/ds-caselaw-data-enrichment-service)
 
 Marks up judgments in [Find Case Law](https://caselaw.nationalarchives.gov.uk) with references to other cases and legislation.
 

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -7,12 +7,12 @@ spaczz==0.6.1
 lxml==5.4.0
 testing.postgresql==1.3.0
 sqlalchemy==2.0.41
-coverage==7.9.2
 boto==2.49.0
 moto==5.1.8
 mock==5.2.0
 pytest==8.4.1
 pytest-postgresql==7.0.2
+pytest-cov==6.2.1
 psycopg==3.2.9
 SPARQLWrapper==2.0.0
 python-dotenv==1.1.1


### PR DESCRIPTION
To unclog tests, extract the replacement of Codeclimate with CodeCov from #1108.