### PR TITLE
Pin terraform-docs go version to 1.24.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,8 @@ repos:
     hooks:
       - id: terraform-docs-go
         args: ["markdown", "table", "--output-file", "README.md", "./terraform"]
+        # remove when https://github.com/terraform-docs/terraform-docs/issues/870 resolved
+        language_version: "1.24.6"
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6


### PR DESCRIPTION
I was having this issue: https://github.com/terraform-docs/terraform-docs/issues/870

<!-- Amend as appropriate -->

## Changes in this PR:

### Jira card / Rollbar error (etc)

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
