### PR TITLE
fix(FCLC-1833): updated value in main.tf from 16.8 to 16.11 for aurora postgres

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,7 +54,7 @@ module "data" {
 
   aurora_rds = {
     "main" = {
-      engine_version = "16.8"
+      engine_version = "16.11"
       instance_type  = "db.t3.medium"
       allowed_security_groups = [
         module.network.default_security_group_id,


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Updated the value in main.tf from 16.8 to 16.11 for the aurora_rds postgres version to solve the issue during the staging-prod deployment process whereby postgres in aurora_rds can't be downgraded to 16.8 from 16.11

### Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCLC-1833

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
