### PR TITLE
fix(FCLC-1833): Updated lambda.tf and deploy_single_env.yml 

### DIFF
--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -315,6 +315,17 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
 
 
+          ###########################
+          ## UPDATE_LEGISLATION_TABLE
+
+          cd "src/lambdas/update_legislation_table"
+          docker buildx build --load -t tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }} .
+          docker tag tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }}:latest ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }}:latest
+          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }}:latest
+          aws lambda update-function-code --function-name tna-s3-tna-${{ secrets.app_env }}-update-legislation-table --image-uri ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }}:latest
+          cd "${GITHUB_WORKSPACE}"
+
+
           #########################
           ## UPDATE_RULES_PROCESSOR
 

--- a/terraform/modules/lambda_s3/lambda.tf
+++ b/terraform/modules/lambda_s3/lambda.tf
@@ -937,9 +937,13 @@ module "lambda-update-legislation-table" {
 
   # Lambda function declaration
   function_name = "${local.name}-${local.environment}-update-legislation-table"
-  package_type  = var.use_container_image == true ? "Image" : "Zip"
+
+  package_type   = "Image"
+  create_package = false
 
   runtime = "python3.12" # Setting runtime is required when building package in Docker and Lambda Layer resource.
+
+  image_uri = "${aws_ecr_repository.legislation-update.repository_url}:${var.container_image_tag}"
 
   # Deploy as code
   handler = "index.handler"


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR:

Updated lambda.tf to incorporate docker images built by deploy_single_env.yml for update_legislation_table lambda as it's causing the pipeline to fail as a zipped file instead of a docker image due to hash mismatches. If it pulls a docker image rather than the zip the hash should stay stable and terraform won't have an issue with this one.

### Jira card / Rollbar error (etc)

- [ ] Increase the version number in src/lambdas/determine_legislation_provisions/index.py
- [ ] Update CHANGELOG.md
- [ ] Requires env variable(s) to be updated
