### PR TITLE
fix(lambda): resolve runtime import errors with absolute import strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci_lint_and_test
+name: ci
 permissions: {}
 on:
   pull_request:
@@ -60,8 +60,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
-  build-lambda-images:
-    name: Build ${{ matrix.lambda }}
+  smoke-test:
+    name: Smoke test ${{ matrix.lambda }}
+    needs: run-tests
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     strategy:
@@ -74,13 +75,25 @@ jobs:
           - update_rules_processor
     steps:
       - name: Checkout source code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Build ${{ matrix.lambda }}
-        run: make build-lambda LAMBDA=${{ matrix.lambda }}
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          install: true
+
+      - name: Run smoke test for ${{ matrix.lambda }}
+        env:
+          DOCKER_BUILDKIT: 1
+        run: make smoke-test LAMBDA=${{ matrix.lambda }}
 
   terraform_format:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -15,7 +15,7 @@ on:
         required: true
 
 jobs:
-  deploy_single_environment:
+  setup-terraform-phase-1:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
@@ -36,11 +36,6 @@ jobs:
           aws-region: eu-west-2
           role-to-assume: ${{ secrets.aws_oidc_role_arn }}
         continue-on-error: false
-
-      - name: Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          install: true
 
       - name: Assemble Lambdas
         run: |
@@ -86,32 +81,113 @@ jobs:
             -target=module.lambda_s3.aws_ecr_lifecycle_policy.ru_retention \
             -var "app_env=${{ secrets.app_env }}"
 
-      - name: Build and Push Docker Images
+  build-and-push-lambda:
+    name: Build and push ${{ matrix.lambda }}
+    needs: setup-terraform-phase-1
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        lambda:
+          - enrichment_lambda
+          - db_backup
+          - update_legislation_table
+          - update_rules_processor
+        include:
+          - lambda: enrichment_lambda
+            ecr_repo: tna-s3-tna-ecr-repository-enrichment
+          - lambda: db_backup
+            ecr_repo: tna-s3-tna-ecr-repository-db-backup
+          - lambda: update_legislation_table
+            ecr_repo: tna-s3-tna-ecr-repository-legislation-update
+          - lambda: update_rules_processor
+            ecr_repo: tna-s3-tna-ecr-repository-rules-update
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Get AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.aws_oidc_role_arn }}
+        continue-on-error: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          install: true
+
+      - name: Build and push ${{ matrix.lambda }}
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           set -e
           set -o pipefail
 
           aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com
 
-          ## ENRICHMENT (consolidated pipeline)
-          make build-lambda LAMBDA=enrichment_lambda ASSEMBLED=1
-          docker tag enrichment_lambda:local ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-enrichment-${{ secrets.app_env }}:latest
-          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-enrichment-${{ secrets.app_env }}:latest
+          make build-lambda LAMBDA=${{ matrix.lambda }} ASSEMBLED=1
 
-          ## DB_BACKUP
-          make build-lambda LAMBDA=db_backup ASSEMBLED=1
-          docker tag db_backup:local ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-db-backup-${{ secrets.app_env }}:latest
-          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-db-backup-${{ secrets.app_env }}:latest
+      - name: Smoke test ${{ matrix.lambda }}
+        env:
+          DOCKER_BUILDKIT: 1
+        run: make smoke-test LAMBDA=${{ matrix.lambda }}
 
-          ## UPDATE_LEGISLATION_TABLE
-          make build-lambda LAMBDA=update_legislation_table ASSEMBLED=1
-          docker tag update_legislation_table:local ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }}:latest
-          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-legislation-update-${{ secrets.app_env }}:latest
+      - name: Push ${{ matrix.lambda }} to ECR
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          set -e
+          set -o pipefail
 
-          ## UPDATE_RULES_PROCESSOR
-          make build-lambda LAMBDA=update_rules_processor ASSEMBLED=1
-          docker tag update_rules_processor:local ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-rules-update-${{ secrets.app_env }}:latest
-          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/tna-s3-tna-ecr-repository-rules-update-${{ secrets.app_env }}:latest
+          aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com
+
+          docker tag ${{ matrix.lambda }}:local ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/${{ matrix.ecr_repo }}-${{ secrets.app_env }}:latest
+          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/${{ matrix.ecr_repo }}-${{ secrets.app_env }}:latest
+
+  deploy-terraform-phase-2:
+    name: Deploy infrastructure
+    needs: build-and-push-lambda
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Get AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.aws_oidc_role_arn }}
+        continue-on-error: false
+
+      - name: Get terraform version
+        id: get-terraform-version
+        run: |
+          DOTFILE_VERSION=$(cat terraform/.terraform-version)
+          echo "version=$DOTFILE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        continue-on-error: false
+        with:
+          terraform_version: ${{ steps.get-terraform-version.outputs.version }}
+
+      - name: Terraform init
+        run: |
+          set -e
+          set -o pipefail
+          cd terraform
+          terraform init -upgrade -input=false -backend-config="bucket=tna-terraform-backend-state-enrichment-pipeline-${{ secrets.account_id }}"
+        continue-on-error: false
 
       - name: "Terraform Phase 2: Deploy Complete Infrastructure"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,20 @@
 SHELL := /bin/bash
 
-.PHONY: setup test assemble-lambda-contexts build-lambdas build-lambda clean
+.PHONY: setup test build-lambdas build-lambda smoke-test validate clean
 
 setup:
 	@echo "Setting up local development environment..."
 	poetry install --with enrichment-lambda,legislation-lambda,rules-lambda,backup-lambda,test
 	@echo "Development environment ready. Use 'make test' to run tests or 'make build-lambdas' to build."
 
-test: clean
+test:
 	poetry run pytest ${TEST_ARGS}
 
-assemble-lambda-contexts:
-	./scripts/assemble_lambda_contexts.sh
-
-build-lambdas: assemble-lambda-contexts
+build-lambdas:
 	@for lambda in src/lambdas/*/; do \
 		if [ -f "$$lambda/Dockerfile" ]; then \
 			name=$$(basename $$lambda); \
-			$(MAKE) build-lambda LAMBDA=$$name ASSEMBLED=1 || exit 1; \
+			$(MAKE) build-lambda LAMBDA=$$name || exit 1; \
 		fi \
 	done
 
@@ -27,13 +24,64 @@ build-lambda:
 		echo "Available lambdas: $$(ls src/lambdas/)"; \
 		exit 1; \
 	fi
-	@if [ "$(ASSEMBLED)" != "1" ]; then \
-		$(MAKE) assemble-lambda-contexts; \
-	fi
 	@echo "Building $(LAMBDA)..."
 	docker build -f "src/lambdas/$(LAMBDA)/Dockerfile" -t $(LAMBDA):local .
 
+smoke-test:
+	@if [ -z "$(LAMBDA)" ]; then \
+		echo "Running smoke tests for all lambdas..."; \
+		$(MAKE) build-lambdas; \
+		lambdas="enrichment_lambda update_legislation_table update_rules_processor db_backup"; \
+	else \
+		echo "Running smoke test for $(LAMBDA)..."; \
+		docker build -f "src/lambdas/$(LAMBDA)/Dockerfile" -t $(LAMBDA):local . > /dev/null; \
+		lambdas="$(LAMBDA)"; \
+	fi; \
+	failed=0; \
+	for lambda in $$lambdas; do \
+		echo ""; \
+		echo "=== Smoke test: $$lambda ==="; \
+		docker run -d --name $$lambda-smoke-test -p 9000:8080 $$lambda:local 2>/dev/null; \
+		sleep 3; \
+		if curl -s -f http://localhost:9000/2015-03-31/functions/function/invocations \
+			-X POST \
+			-H "Content-Type: application/json" \
+			-d '{"test":"ping"}' > /dev/null 2>&1; then \
+			echo "✓ $$lambda container is healthy"; \
+			if [ -f "tests/lambda_tests/smoke_test_events/$${lambda}_test_event.json" ]; then \
+				curl -s -X POST \
+					http://localhost:9000/2015-03-31/functions/function/invocations \
+					-H "Content-Type: application/json" \
+					--data-binary @tests/lambda_tests/smoke_test_events/$${lambda}_test_event.json > /tmp/$${lambda}_response.json; \
+				if jq empty /tmp/$${lambda}_response.json 2>/dev/null; then \
+					echo "✓ $$lambda responds with valid JSON"; \
+				else \
+					echo "✗ $$lambda response is not valid JSON"; \
+					failed=1; \
+				fi; \
+			fi; \
+		else \
+			echo "✗ $$lambda container failed to start"; \
+			docker logs $$lambda-smoke-test; \
+			failed=1; \
+		fi; \
+		docker stop $$lambda-smoke-test 2>/dev/null; \
+		docker rm $$lambda-smoke-test 2>/dev/null; \
+	done; \
+	echo ""; \
+	if [ $$failed -eq 1 ]; then \
+		echo "✗ Smoke tests failed"; \
+		exit 1; \
+	else \
+		echo "✓ Smoke tests passed"; \
+	fi
+
+validate: test build-lambdas smoke-test
+	@echo ""
+	@echo "✓ All validations passed!"
+	@echo "  - Unit tests: PASS"
+	@echo "  - Lambda builds: PASS"
+	@echo "  - Smoke tests: PASS"
+
 clean:
-	@echo "Cleaning generated assembly files..."
-	rm -rf src/lambdas/*/utils src/lambdas/*/database
 	@echo "Clean complete."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is part of the [Find Case Law](https://caselaw.nationalarchives.
 
 # Judgment Enrichment Pipeline
 
-![Tests](https://img.shields.io/github/actions/workflow/status/nationalarchives/ds-caselaw-data-enrichment-service/ci_lint_and_test.yml?branch=main&label=tests)
+![Tests](https://img.shields.io/github/actions/workflow/status/nationalarchives/ds-caselaw-data-enrichment-service/ci.yml?branch=main&label=tests)
 ![Code Coverage](https://img.shields.io/codecov/c/github/nationalarchives/ds-caselaw-data-enrichment-service)
 
 Marks up judgments in [Find Case Law](https://caselaw.nationalarchives.gov.uk) with references to other cases and legislation.
@@ -150,32 +150,11 @@ coverage report
 
 ### CI execution
 
-Tests are executed in CI as part of the GitHub Actions workflow (.github/workflows/ci_lint_and_test.yml).
+Tests are executed in CI as part of the GitHub Actions workflow (.github/workflows/ci.yml).
 
-## Building Lambda Functions
+## Building and Validating Lambda Functions
 
-Use Make targets as the single public interface for local and CI builds.
-
-```bash
-make build-lambdas
-make build-lambda LAMBDA=enrichment_lambda
-```
-
-Build principles:
-
-- One dependency source of truth: `pyproject.toml` + `poetry.lock`
-- One build implementation: `make build-lambda`
-- Consistent behavior across local, PR CI, and deploy CI
-
-Where implementation details live:
-
-- Build orchestration: `Makefile`
-- Lambda image definitions: `src/lambdas/*/Dockerfile`
-- Context assembly script: `scripts/assemble_lambda_contexts.sh`
-- PR CI matrix: `.github/workflows/ci_lint_and_test.yml`
-- Deploy workflow: `.github/workflows/deploy_single_environment.yml`
-
-CI and deploy both call `make build-lambda`; `make build-lambdas` is a convenience wrapper that delegates to `make build-lambda` for each lambda.
+Use Make targets as the single public interface for local and CI validation/builds.
 
 ## Make Targets Reference
 
@@ -184,26 +163,67 @@ CI and deploy both call `make build-lambda`; `make build-lambdas` is a convenien
 | Target                      | Description                                                                  |
 | --------------------------- | ---------------------------------------------------------------------------- |
 | `make setup`                | Install all dependencies for development and testing                         |
-| `make test`                 | Run all tests (cleans artifacts first)                                       |
+| `make test`                 | Run all tests with pytest                                                    |
 | `make test TEST_ARGS="..."` | Run tests with custom pytest args (e.g., `-k test_name` or `-m integration`) |
 
-### Building
+### Building & Validation
 
-| Target                            | Description                                                     |
-| --------------------------------- | --------------------------------------------------------------- |
-| `make assemble-lambda-contexts`   | Copy shared utils/ and database/ into lambda directories        |
-| `make build-lambdas`              | Build all lambda Docker images (delegates to `build-lambda`)    |
-| `make build-lambda LAMBDA=<name>` | Build one lambda image (assembles unless `ASSEMBLED=1`)         |
-| `make clean`                      | Remove assembled artifacts (utils/, database/) from lambda dirs |
+| Target                            | Description                                                                |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `make build-lambdas`              | Build all Lambda Docker images for local testing                           |
+| `make build-lambda LAMBDA=<name>` | Build one Lambda image                                                     |
+| `make smoke-test`                 | Test all Lambda containers using AWS Lambda Runtime Interface (RIE)        |
+| `make smoke-test LAMBDA=<name>`   | Test one specific Lambda container (used by CI matrix for parallelization) |
+| `make validate`                   | Full validation pipeline: test → build-lambdas → smoke-test                |
+| `make clean`                      | Clean Docker build artifacts                                               |
 
-### Example workflows
+### Smoke Testing Strategy
 
-```bash
-make setup
-make test
-make build-lambdas
-make clean
+**Local:** `make smoke-test` builds Lambda Docker images and validates them with AWS Lambda Runtime Interface Emulator (RIE). Runs all 4 lambdas sequentially, or with `LAMBDA=<name>` for a single lambda.
+
+**CI/CD:** `.github/workflows/ci.yml` runs unit tests first, then invokes `make smoke-test LAMBDA=<name>` for each lambda in parallel (4 jobs). `.github/workflows/deploy_single_environment.yml` builds and smoke tests all 4 lambdas in parallel before pushing to ECR, ensuring broken images never reach production.
+
+**Full validation:** `make validate` runs unit tests → builds all lambdas → smoke tests all containers. This is the comprehensive pre-commit gate.
+
+Build principles:
+
+- One dependency source of truth: `pyproject.toml` + `poetry.lock`
+- Selective COPY in Dockerfiles (not full `src/`): Preserves build cache granularity
+- Dependencies installed before source: Code changes don't force dependency reinstall
+- One build implementation: `make build-lambda`
+- Consistent behavior across local, PR CI, and deploy CI
+
+Where implementation details live:
+
+- Build orchestration: `Makefile`
+- Lambda image definitions: `src/lambdas/*/Dockerfile`
+- CI pipeline: `.github/workflows/ci.yml` (unit tests → parallel smoke tests)
+- Deployment pipeline: `.github/workflows/deploy_single_environment.yml` (parallel build → smoke test → ECR push → Terraform deploy)
+
+## Repository Structure and Build Process
+
+The `src/` directory contains all code used by both tests and Docker builds:
+
 ```
+src/
+├── lambdas/                    # Lambda entry points (enrichment, legislation, rules, backup)
+├── enrichment/                 # Enrichment modules
+├── database/                   # Shared database utilities
+└── utils/                      # Shared utilities
+```
+
+**Testing with absolute imports:** `pytest.ini` adds `src/` to pythonpath, enabling:
+
+```python
+from lambdas.enrichment_lambda.api import read_message
+from utils.environment_helpers import validate_env_variable
+```
+
+**Docker builds:** Dockerfiles at `src/lambdas/{lambda_name}/Dockerfile` are built with `docker build -f "src/lambdas/$(LAMBDA)/Dockerfile" -t $(LAMBDA):local .`
+
+- Install dependencies first (Poetry layers reused across code changes)
+- Selectively copy only: `src/utils/`, `src/database/`, `src/lambdas/{name}/`, and `src/enrichment/` (enrichment_lambda only)
+- Result: Build caches stay granular; code changes don't force dependency reinstall
 
 ## Turning Enrichment Off
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = src
 addopts = -p no:socket
 env =
     SOURCE_BUCKET=TEST_SOURCE_BUCKET

--- a/src/lambdas/db_backup/__init__.py
+++ b/src/lambdas/db_backup/__init__.py
@@ -1,0 +1,1 @@
+"""DB Backup Lambda package."""

--- a/src/lambdas/db_backup/dockerfile
+++ b/src/lambdas/db_backup/dockerfile
@@ -11,7 +11,11 @@ COPY pyproject.toml poetry.lock ${LAMBDA_TASK_ROOT}/
 # Install dependencies (backup lambda uses core deps only)
 RUN cd ${LAMBDA_TASK_ROOT} && poetry config virtualenvs.create false && poetry install --no-root
 
-# Copy lambda code
-COPY src/lambdas/db_backup/index.py ${LAMBDA_TASK_ROOT}/
+# Copy shared utilities and database modules (needed by all lambdas)
+COPY src/utils ${LAMBDA_TASK_ROOT}/utils
+COPY src/database ${LAMBDA_TASK_ROOT}/database
 
-CMD [ "index.lambda_handler" ]
+# Copy this lambda's code
+COPY src/lambdas/db_backup ${LAMBDA_TASK_ROOT}/lambdas/db_backup
+
+CMD ["lambdas.db_backup.index.lambda_handler"]

--- a/src/lambdas/enrichment_lambda/Dockerfile
+++ b/src/lambdas/enrichment_lambda/Dockerfile
@@ -11,11 +11,14 @@ COPY pyproject.toml poetry.lock ${LAMBDA_TASK_ROOT}/
 # Install dependencies with enrichment-lambda group
 RUN cd ${LAMBDA_TASK_ROOT} && poetry config virtualenvs.create false && poetry install --with enrichment-lambda --no-root
 
-# Copy lambda code and shared utils/database modules (assembled by make)
-COPY src/lambdas/enrichment_lambda/index.py ${LAMBDA_TASK_ROOT}/
-COPY src/lambdas/enrichment_lambda/utils/ ${LAMBDA_TASK_ROOT}/utils/
-COPY src/lambdas/enrichment_lambda/database/ ${LAMBDA_TASK_ROOT}/database/
-COPY src/lambdas/enrichment_lambda/steps.py ${LAMBDA_TASK_ROOT}/
-COPY src/lambdas/enrichment_lambda/api.py ${LAMBDA_TASK_ROOT}/
+# Copy shared utilities and database modules (needed by all lambdas)
+COPY src/utils ${LAMBDA_TASK_ROOT}/utils
+COPY src/database ${LAMBDA_TASK_ROOT}/database
 
-CMD ["index.handler"]
+# Copy enrichment modules (specific to this lambda)
+COPY src/enrichment ${LAMBDA_TASK_ROOT}/enrichment
+
+# Copy this lambda's code
+COPY src/lambdas/enrichment_lambda ${LAMBDA_TASK_ROOT}/lambdas/enrichment_lambda
+
+CMD ["lambdas.enrichment_lambda.index.handler"]

--- a/src/lambdas/enrichment_lambda/__init__.py
+++ b/src/lambdas/enrichment_lambda/__init__.py
@@ -1,0 +1,1 @@
+"""Enrichment Lambda package."""

--- a/src/lambdas/update_legislation_table/Dockerfile
+++ b/src/lambdas/update_legislation_table/Dockerfile
@@ -11,9 +11,11 @@ COPY pyproject.toml poetry.lock ${LAMBDA_TASK_ROOT}/
 # Install dependencies with legislation-lambda group
 RUN cd ${LAMBDA_TASK_ROOT} && poetry config virtualenvs.create false && poetry install --with legislation-lambda --no-root
 
-# Copy lambda code and shared utils/database modules (assembled by make)
-COPY src/lambdas/update_legislation_table/index.py ${LAMBDA_TASK_ROOT}/
-COPY src/lambdas/update_legislation_table/utils/ ${LAMBDA_TASK_ROOT}/utils/
-COPY src/lambdas/update_legislation_table/database/ ${LAMBDA_TASK_ROOT}/database/
+# Copy shared utilities and database modules (needed by all lambdas)
+COPY src/utils ${LAMBDA_TASK_ROOT}/utils
+COPY src/database ${LAMBDA_TASK_ROOT}/database
 
-CMD [ "index.lambda_handler" ]
+# Copy this lambda's code
+COPY src/lambdas/update_legislation_table ${LAMBDA_TASK_ROOT}/lambdas/update_legislation_table
+
+CMD ["lambdas.update_legislation_table.index.handler"]

--- a/src/lambdas/update_legislation_table/__init__.py
+++ b/src/lambdas/update_legislation_table/__init__.py
@@ -1,0 +1,1 @@
+"""Update Legislation Table Lambda package."""

--- a/src/lambdas/update_legislation_table/tests/test_remove_duplicates.py
+++ b/src/lambdas/update_legislation_table/tests/test_remove_duplicates.py
@@ -1,6 +1,6 @@
 from sqlalchemy import text
 
-from ..database import remove_duplicates
+from lambdas.update_legislation_table.database import remove_duplicates
 
 
 def test_remove_duplicates(db_connection):

--- a/src/lambdas/update_rules_processor/Dockerfile
+++ b/src/lambdas/update_rules_processor/Dockerfile
@@ -11,9 +11,11 @@ COPY pyproject.toml poetry.lock ${LAMBDA_TASK_ROOT}/
 # Install dependencies with rules-lambda group
 RUN cd ${LAMBDA_TASK_ROOT} && poetry config virtualenvs.create false && poetry install --with rules-lambda --no-root
 
-# Copy lambda code and shared utils/database modules (assembled by make)
-COPY src/lambdas/update_rules_processor/index.py ${LAMBDA_TASK_ROOT}/
-COPY src/lambdas/update_rules_processor/utils/ ${LAMBDA_TASK_ROOT}/utils/
-COPY src/lambdas/update_rules_processor/database/ ${LAMBDA_TASK_ROOT}/database/
+# Copy shared utilities and database modules (needed by all lambdas)
+COPY src/utils ${LAMBDA_TASK_ROOT}/utils
+COPY src/database ${LAMBDA_TASK_ROOT}/database
 
-CMD [ "index.lambda_handler" ]
+# Copy this lambda's code
+COPY src/lambdas/update_rules_processor ${LAMBDA_TASK_ROOT}/lambdas/update_rules_processor
+
+CMD ["lambdas.update_rules_processor.index.lambda_handler"]

--- a/src/lambdas/update_rules_processor/__init__.py
+++ b/src/lambdas/update_rules_processor/__init__.py
@@ -1,0 +1,1 @@
+"""Update Rules Processor Lambda package."""

--- a/tests/lambda_tests/smoke_test_events/db_backup_test_event.json
+++ b/tests/lambda_tests/smoke_test_events/db_backup_test_event.json
@@ -1,0 +1,13 @@
+{
+  "version": "0",
+  "id": "test-event-id",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "2024-01-01T12:00:00Z",
+  "region": "eu-west-2",
+  "resources": ["arn:aws:events:eu-west-2:123456789012:rule/test-rule"],
+  "detail": {
+    "trigger": "scheduled-db-backup"
+  }
+}

--- a/tests/lambda_tests/smoke_test_events/enrichment_lambda_test_event.json
+++ b/tests/lambda_tests/smoke_test_events/enrichment_lambda_test_event.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "test-message-id",
+      "receiptHandle": "test-receipt-handle",
+      "body": "{\"Records\": [{\"EventSource\": \"aws:sns\", \"Sns\": {\"Message\": \"{\\\"judgment_uri\\\": \\\"test-judgment\\\"}\", \"MessageAttributes\": {\"trigger_enrichment\": {\"Type\": \"String\", \"Value\": \"true\"}}}}]}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1234567890",
+        "SenderId": "test-sender",
+        "ApproximateFirstReceiveTimestamp": "1234567890"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "test-md5",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:test-queue",
+      "awsRegion": "eu-west-2"
+    }
+  ]
+}

--- a/tests/lambda_tests/smoke_test_events/update_legislation_table_test_event.json
+++ b/tests/lambda_tests/smoke_test_events/update_legislation_table_test_event.json
@@ -1,0 +1,13 @@
+{
+  "version": "0",
+  "id": "test-event-id",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "2024-01-01T12:00:00Z",
+  "region": "eu-west-2",
+  "resources": ["arn:aws:events:eu-west-2:123456789012:rule/test-rule"],
+  "detail": {
+    "trigger": "scheduled-legislation-update"
+  }
+}

--- a/tests/lambda_tests/smoke_test_events/update_rules_processor_test_event.json
+++ b/tests/lambda_tests/smoke_test_events/update_rules_processor_test_event.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "awsRegion": "eu-west-2",
+      "eventTime": "2024-01-01T12:00:00.000Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "test-principal"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "192.0.2.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "test-request-id",
+        "x-amz-id-2": "test-id"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "test-config",
+        "bucket": {
+          "name": "test-bucket",
+          "ownerIdentity": {
+            "principalId": "test-principal"
+          },
+          "arn": "arn:aws:s3:::test-bucket"
+        },
+        "object": {
+          "key": "test-rules.jsonl",
+          "size": 1024,
+          "eTag": "test-etag",
+          "sequencer": "test-sequencer"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Lambdas deployed successfully but failed when triggered due to broken import paths. Implemented clean, absolute imports that work identically in tests and Docker.

Changes:
- Updated Dockerfiles: selective COPY (utils, database, lambda-specific code)
- Added pytest.ini pythonpath=src for absolute imports in tests
- Optimized Docker layers: dependencies installed before code copying
- Added smoke-tests to makefile and ci ensure broken docker runtimes dont reach deployment

### Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-1833