### PR TITLE
Stop delaying enrichment requests

### DIFF
--- a/src/lambdas/enrichment_lambda/enrich_judgment.py
+++ b/src/lambdas/enrichment_lambda/enrich_judgment.py
@@ -23,11 +23,11 @@ def enrich_judgment(
 ) -> None:
     LOGGER.info("Enriching judgment: %s", uri_reference)
 
-    LOGGER.info("Fetching judgment from API endpoint: %s", api_endpoint)
-    xml_content = fetch_judgment(api_endpoint, uri_reference, api_username, api_password)
-
     LOGGER.info("Locking judgment: %s", uri_reference)
     lock_judgment(api_endpoint, uri_reference, api_username, api_password)
+
+    LOGGER.info("Fetching judgment from API endpoint: %s", api_endpoint)
+    xml_content = fetch_judgment(api_endpoint, uri_reference, api_username, api_password)
 
     LOGGER.info("Enriching judgment content for: %s", uri_reference)
     enriched_xml = enrich_xml(xml_content, pattern_list, enrichment_version="7.4.0")

--- a/src/tests/lambda_tests/enrichment_lambda/test_enrich_judgment.py
+++ b/src/tests/lambda_tests/enrichment_lambda/test_enrich_judgment.py
@@ -90,7 +90,7 @@ class TestEnrichJudgment:
         with pytest.raises(Exception, match="API error"):
             enrich_judgment(uri_reference, endpoint, "user", "pass", [])
 
-        mock_lock.assert_not_called()
+        mock_lock.assert_called()
         mock_enrich.assert_not_called()
         mock_patch.assert_not_called()
 
@@ -153,7 +153,7 @@ class TestEnrichJudgment:
         with pytest.raises(Exception, match="Lock failed"):
             enrich_judgment(uri_reference, endpoint, "user", "pass", [])
 
-        mock_fetch.assert_called_once()
+        mock_fetch.assert_not_called()
         mock_enrich.assert_not_called()
         mock_patch.assert_not_called()
 

--- a/terraform/modules/lambda_s3/queue.tf
+++ b/terraform/modules/lambda_s3/queue.tf
@@ -4,7 +4,6 @@
 
 resource "aws_sqs_queue" "enrichment_queue" {
   name                       = "${local.name}-${local.environment}-enrichment-queue"
-  delay_seconds              = 90
   max_message_size           = 2048
   visibility_timeout_seconds = 900
   message_retention_seconds  = 1209600
@@ -19,7 +18,6 @@ resource "aws_sqs_queue" "enrichment_queue" {
 
 resource "aws_sqs_queue" "enrichment_dlq_queue" {
   name                      = "${local.name}-${local.environment}-enrichment-dlq-queue"
-  delay_seconds             = 90
   max_message_size          = 2048
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10


### PR DESCRIPTION
## Changes in this PR:
- Lock the judgment before fetching it in the enrichment pipeline to avoid race conditions
- Stop delaying enrichment messages in sqs queue from tiggering the enrichment lambda for 90 seconds and similarly for its dlq

### Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-1833