### PR TITLE
Full enrichment e2e test

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,56 @@
+# Copy to .env.e2e and fill values for E2E.
+# This file is read by src/tests/end_to_end_tests/test_marklogic_e2e.py
+
+# Toggle test execution
+E2E_RUN=true
+
+# Trigger mode:
+# - sqs: triggers deployed lambda via SQS
+# - local_handler: executes local handler() against target resources
+E2E_TRIGGER_MODE=sqs
+
+# AWS auth/region
+AWS_PROFILE=
+AWS_REGION=eu-west-2
+
+# Queue name for sqs trigger mode
+SQS_ENRICHMENT_QUEUE_NAME=
+
+# API access (combined secret with username/password)
+API_SECRET_NAME=
+ENVIRONMENT=staging
+
+# Lambda runtime resources
+RULES_FILE_BUCKET=
+RULES_FILE_KEY=citation_patterns.jsonl
+VCITE_BUCKET=
+VCITE_ENRICHED_BUCKET=
+
+# Disposable target URI must include one of: e2e, test-fixture, staging-e2e
+E2E_URI=
+E2E_REQUIRE_DISPOSABLE_URI=true
+
+# Optional disposable fixture seeding from repo XML.
+# Disabled by default. When E2E_SEED_IF_MISSING=true and E2E_URI
+# does not exist, the test seeds a temporary document in MarkLogic and deletes it at the end.
+E2E_SEED_IF_MISSING=false
+E2E_SOURCE_XML_PATH=test_files/ewca_civ_2025_673-original.xml
+MARKLOGIC_API_CLIENT_HOST=
+# Set explicitly to true or false.
+MARKLOGIC_USE_HTTPS=false
+# Default: reuses API_SECRET_NAME above for fixture-seeding credentials.
+# Only set these if fixture-seeding credentials are different:
+# MARKLOGIC_SECRET_NAME=
+# MARKLOGIC_USERNAME=
+# MARKLOGIC_PASSWORD=
+
+# Timing and cleanup
+E2E_TIMEOUT_SECONDS=240
+E2E_RESTORE_ORIGINAL=false
+
+# Required only for local_handler mode (typically with SSM DB tunnel)
+# DATABASE_NAME=rules
+# DATABASE_USERNAME=root
+# DB_PASSWORD_SECRET_NAME=
+# E2E_DB_HOST=127.0.0.1
+# E2E_DB_PORT=15432

--- a/.github/workflows/cd_deploy_staging_then_prod.yml
+++ b/.github/workflows/cd_deploy_staging_then_prod.yml
@@ -32,10 +32,63 @@ jobs:
     permissions:
       id-token: write
 
+  verify_staging_e2e:
+    name: Verify Staging Deployment (E2E SQS)
+    needs: deploy_staging
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pip3 install poetry==2.1.3
+
+      - name: Install dependencies
+        run: make setup
+
+      - name: Get AWS Credentials
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
+      - name: Run E2E verification in SQS mode
+        env:
+          E2E_RUN: "true"
+          E2E_TRIGGER_MODE: sqs
+          E2E_SEED_IF_MISSING: "true"
+          E2E_RESTORE_ORIGINAL: "false"
+          E2E_TIMEOUT_SECONDS: "300"
+          E2E_SOURCE_XML_PATH: test_files/ewca_civ_2025_673-original.xml
+          E2E_URI: staging-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          AWS_REGION: eu-west-2
+          ENVIRONMENT: staging
+          API_SECRET_NAME: ${{ secrets.E2E_API_SECRET_NAME }}
+          SQS_ENRICHMENT_QUEUE_NAME: tna-s3-tna-staging-enrichment-queue
+          RULES_FILE_BUCKET: staging-tna-s3-tna-sg-rules-bucket
+          RULES_FILE_KEY: citation_patterns.jsonl
+          VCITE_BUCKET: vcite-tna-files
+          VCITE_ENRICHED_BUCKET: foo
+          MARKLOGIC_API_CLIENT_HOST: ${{ secrets.E2E_MARKLOGIC_API_CLIENT_HOST }}
+          MARKLOGIC_USE_HTTPS: "false"
+        run: make test-e2e
+
   # deploy_production:
   #   name: Deploy Production Build
   #   uses: ./.github/workflows/deploy_single_environment.yml
-  #   needs: deploy_staging
+  #   needs: verify_staging_e2e
   #   with:
   #     environment: production
   #   secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.e2e
 *venv
 env/
 ENV/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: setup test build-lambdas build-lambda smoke-test validate clean
+.PHONY: setup test test-e2e build-lambdas build-lambda smoke-test validate clean
 
 setup:
 	@echo "Setting up local development environment..."
@@ -8,7 +8,10 @@ setup:
 	@echo "Development environment ready. Use 'make test' to run tests or 'make build-lambdas' to build."
 
 test:
-	poetry run pytest ${TEST_ARGS}
+	poetry run pytest -m "not e2e" ${TEST_ARGS}
+
+test-e2e:
+	poetry run pytest -m e2e src/tests/end_to_end_tests/test_marklogic_e2e.py -rs -vvv -s -q ${TEST_ARGS}
 
 build-lambdas:
 	@for lambda in src/lambdas/*/; do \

--- a/README.md
+++ b/README.md
@@ -139,6 +139,98 @@ Run tests excluding integration tests:
 make test TEST_ARGS="-m 'not integration'"
 ```
 
+### E2E (Opt-in)
+
+There is an opt-in E2E test at `src/tests/end_to_end_tests/test_marklogic_e2e.py`.
+
+Prerequisite: your machine/runner must have network access to the target MarkLogic/API endpoints used by this test (including fixture seed/delete checks). For TNA staging, this typically means DXW VPN access.
+
+Use an env file so you do not need to export variables every run:
+
+```bash
+cp .env.e2e.example .env.e2e
+```
+
+Fill values in `.env.e2e` and export it, then run:
+
+```bash
+make test-e2e
+```
+
+Default test runs (`make test`) exclude E2E tests by marker.
+
+Core required settings:
+
+- `E2E_RUN=true`
+- `AWS_REGION` (or `AWS_DEFAULT_REGION`)
+- `ENVIRONMENT` (for example `staging`)
+- `API_SECRET_NAME` (secret JSON with `username` and `password`)
+- `E2E_URI` (must contain one of: `e2e`, `test-fixture`, `staging-e2e`)
+- `MARKLOGIC_API_CLIENT_HOST` (host[:port], no scheme)
+- `MARKLOGIC_USE_HTTPS` (`true`/`false`)
+- `RULES_FILE_BUCKET`
+- `RULES_FILE_KEY`
+- `VCITE_BUCKET`
+- `VCITE_ENRICHED_BUCKET`
+
+Credential behavior for fixture seeding:
+
+- Default: fixture seeding reuses `API_SECRET_NAME` credentials from Secrets Manager.
+- Optional override secret: set `MARKLOGIC_SECRET_NAME` to use a different secret for seeding/deleting fixtures.
+- Optional explicit override: set both `MARKLOGIC_USERNAME` and `MARKLOGIC_PASSWORD`.
+  - If one is set without the other, the test skips with a clear error.
+
+Trigger modes:
+
+- `E2E_TRIGGER_MODE=sqs`: send message to the environment queue (tests deployed lambda path)
+- `E2E_TRIGGER_MODE=local_handler`: call local `handler(...)` with real environment resources
+
+`local_handler` mode also requires:
+
+- `DATABASE_NAME`
+- `DATABASE_USERNAME`
+- `DB_PASSWORD_SECRET_NAME`
+- `E2E_DB_HOST`
+- `E2E_DB_PORT`
+
+For local `local_handler` runs against an environment RDS from your machine, use an SSM port-forward tunnel and point DB env vars to localhost:
+
+```bash
+aws ssm start-session \
+  --target <ec2-instance-id> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<rds-endpoint>"],"portNumber":["5432"],"localPortNumber":["15432"]}' \
+  --profile <aws-profile> \
+  --region <aws-region>
+```
+
+Then set:
+
+- `E2E_DB_HOST=127.0.0.1`
+- `E2E_DB_PORT=15432`
+
+Keep the SSM session terminal open while the test is running.
+
+Seed/restore/delete behavior:
+
+- `E2E_SEED_IF_MISSING=true`: if `E2E_URI` does not exist and `E2E_SOURCE_XML_PATH` is set, the test inserts that XML as a temporary fixture.
+- Seeded fixture is always deleted at the end of the test.
+- Existing URI + `E2E_RESTORE_ORIGINAL=true`: test attempts to patch original XML back after verification.
+- Existing URI + `E2E_RESTORE_ORIGINAL=false`: test leaves enriched result in place.
+
+Recommended CI-safe settings for deployment verification:
+
+- `E2E_TRIGGER_MODE=sqs`
+- `E2E_SEED_IF_MISSING=true`
+- `E2E_RESTORE_ORIGINAL=false`
+- `E2E_SOURCE_XML_PATH=test_files/ewca_civ_2025_673-original.xml`
+- `E2E_URI` generated per run, for example `staging-e2e-${RUN_ID}-${RUN_ATTEMPT}`
+
+Keep environment-specific values (queue names, buckets, secret names, hosts) in environment config rather than README prose:
+
+- Local template: `.env.e2e.example`
+- CI deployment verification: `.github/workflows/cd_deploy_staging_then_prod.yml`
+
 ### Coverage report
 
 You can obtain a coverage report with:
@@ -163,7 +255,8 @@ Use Make targets as the single public interface for local and CI validation/buil
 | Target                      | Description                                                                  |
 | --------------------------- | ---------------------------------------------------------------------------- |
 | `make setup`                | Install all dependencies for development and testing                         |
-| `make test`                 | Run all tests with pytest                                                    |
+| `make test`                 | Run tests with pytest (excludes E2E marker by default)                       |
+| `make test-e2e`             | Run only the E2E pytest suite                                                |
 | `make test TEST_ARGS="..."` | Run tests with custom pytest args (e.g., `-k test_name` or `-m integration`) |
 
 ### Building & Validation

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 pythonpath = src
 addopts = -p no:socket
+markers =
+    e2e: runs end-to-end tests against real AWS/MarkLogic resources
 env =
     SOURCE_BUCKET=TEST_SOURCE_BUCKET
     API_USERNAME=TEST_USERNAME

--- a/src/tests/end_to_end_tests/test_marklogic_e2e.py
+++ b/src/tests/end_to_end_tests/test_marklogic_e2e.py
@@ -1,0 +1,383 @@
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import boto3
+import lxml.etree
+import pytest
+from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.versions import VersionAnnotation, VersionType
+from caselawclient.models.judgments import Judgment
+from dotenv import load_dotenv
+
+from lambdas.enrichment_lambda.api import (
+    fetch_judgment,
+    lock_judgment,
+    patch_judgment,
+)
+from lambdas.enrichment_lambda.index import handler
+from utils.custom_types import APIEndpointBaseURL
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Load project root .env first, then E2E-specific overrides if present.
+# Assuming this file's path is: <repo>/src/tests/end_to_end_tests/test_marklogic_e2e.py
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+load_dotenv(PROJECT_ROOT / ".env")
+load_dotenv(PROJECT_ROOT / ".env.e2e", override=True)
+
+
+@dataclass(frozen=True)
+class E2EConfig:
+    aws_region: str
+    environment: str
+    api_endpoint: APIEndpointBaseURL
+    uri: str
+    api_secret_name: str
+    rules_bucket: str
+    rules_key: str
+    vcite_bucket: str
+    vcite_enriched_bucket: str
+    trigger_mode: str
+    timeout_seconds: int
+    seed_if_missing: bool
+    should_restore: bool
+
+    @classmethod
+    def from_env(cls) -> "E2EConfig":
+        aws_region = _require_any_env("AWS_REGION", "AWS_DEFAULT_REGION")
+        environment = _require_env("ENVIRONMENT")
+        uri = _require_env("E2E_URI")
+
+        return cls(
+            aws_region=aws_region,
+            environment=environment,
+            api_endpoint=_get_api_endpoint(environment),
+            uri=uri,
+            api_secret_name=_require_env("API_SECRET_NAME"),
+            rules_bucket=_require_env("RULES_FILE_BUCKET"),
+            rules_key=_require_env("RULES_FILE_KEY"),
+            vcite_bucket=_require_env("VCITE_BUCKET"),
+            vcite_enriched_bucket=_require_env("VCITE_ENRICHED_BUCKET"),
+            trigger_mode=os.getenv("E2E_TRIGGER_MODE", "sqs").lower(),
+            timeout_seconds=int(os.getenv("E2E_TIMEOUT_SECONDS", "180")),
+            seed_if_missing=os.getenv("E2E_SEED_IF_MISSING", "false") == "true",
+            should_restore=os.getenv("E2E_RESTORE_ORIGINAL", "true") == "true",
+        )
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        pytest.skip(f"Missing required env var for E2E: {name}")
+    return value
+
+
+def _require_any_env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    pytest.skip(f"Missing required env var for E2E: one of {', '.join(names)}")
+
+
+def _resolve_marklogic_fixture_credentials(aws_region: str) -> tuple[str, str]:
+    """Resolve fixture-seeding credentials.
+
+    Defaults to API_SECRET_NAME unless MARKLOGIC_SECRET_NAME is explicitly set.
+    MARKLOGIC_USERNAME/MARKLOGIC_PASSWORD may be used as explicit overrides.
+    """
+    explicit_username = os.getenv("MARKLOGIC_USERNAME")
+    explicit_password = os.getenv("MARKLOGIC_PASSWORD")
+
+    if explicit_username or explicit_password:
+        if not (explicit_username and explicit_password):
+            pytest.skip(
+                "Both MARKLOGIC_USERNAME and MARKLOGIC_PASSWORD must be set when using explicit credentials",
+            )
+        return explicit_username, explicit_password
+
+    secret_name = os.getenv("MARKLOGIC_SECRET_NAME") or _require_env("API_SECRET_NAME")
+    return _resolve_api_credentials_from_secret(secret_name, aws_region)
+
+
+def _create_marklogic_client_for_fixture() -> MarklogicApiClient:
+    host = _require_env("MARKLOGIC_API_CLIENT_HOST")
+    if "://" in host:
+        pytest.skip("MARKLOGIC_API_CLIENT_HOST must be host[:port] without scheme")
+
+    use_https = _require_env("MARKLOGIC_USE_HTTPS").strip().lower() == "true"
+    aws_region = _require_any_env("AWS_REGION", "AWS_DEFAULT_REGION")
+    username, password = _resolve_marklogic_fixture_credentials(aws_region)
+
+    return MarklogicApiClient(
+        host=host,
+        username=username,
+        password=password,
+        use_https=use_https,
+        user_agent=f"ds-caselaw-data-enrichment-service/e2e {DEFAULT_USER_AGENT}",
+    )
+
+
+def _seed_fixture_document_from_repo_xml(target_uri: str) -> bool:
+    source_xml_path = os.getenv("E2E_SOURCE_XML_PATH")
+    if not source_xml_path:
+        return False
+
+    xml_path = Path(source_xml_path)
+    if not xml_path.is_absolute():
+        xml_path = PROJECT_ROOT / xml_path
+
+    if not xml_path.exists():
+        pytest.skip(f"Fixture XML path does not exist: {xml_path}")
+
+    marklogic_client = _create_marklogic_client_for_fixture()
+    target = DocumentURIString(target_uri)
+
+    if marklogic_client.document_exists(target):
+        return False
+
+    xml_element = lxml.etree.fromstring(xml_path.read_bytes())
+    annotation = VersionAnnotation(
+        version_type=VersionType.SUBMISSION,
+        automated=True,
+        message="e2e fixture seed",
+    )
+    marklogic_client.insert_document_xml(target, xml_element, Judgment, annotation)
+
+    # Set published property to false so Priv API can fetch unpublished docs
+    marklogic_client.set_property(target, "published", "false")
+
+    return True
+
+
+def _delete_fixture_document_if_created(target_uri: str, fixture_was_created: bool) -> None:
+    if not fixture_was_created:
+        return
+    marklogic_client = _create_marklogic_client_for_fixture()
+    marklogic_client.delete_judgment(DocumentURIString(target_uri))
+
+
+def _resolve_api_credentials_from_secret(secret_name: str, aws_region: str) -> tuple[str, str]:
+    sm = boto3.client("secretsmanager", region_name=aws_region)
+    secret_string = sm.get_secret_value(SecretId=secret_name)["SecretString"]
+    secret_json = json.loads(secret_string)
+    return secret_json["username"], secret_json["password"]
+
+
+def _get_api_endpoint(environment: str) -> APIEndpointBaseURL:
+    subdomain = "api.staging" if environment == "staging" else "api"
+    return APIEndpointBaseURL(f"https://{subdomain}.caselaw.nationalarchives.gov.uk/")
+
+
+def _get_queue_url(aws_region: str) -> str:
+    queue_name = _require_env("SQS_ENRICHMENT_QUEUE_NAME")
+    sqs = boto3.client("sqs", region_name=aws_region)
+    response = sqs.get_queue_url(QueueName=queue_name)
+    return response["QueueUrl"]
+
+
+def _send_enrichment_message(aws_region: str, queue_url: str, uri_reference: str) -> None:
+    sqs = boto3.client("sqs", region_name=aws_region)
+    message_payload = {
+        "Message": json.dumps(
+            {
+                "status": "ready",
+                "uri_reference": uri_reference,
+            },
+        ),
+    }
+    sqs.send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps(message_payload),
+    )
+
+
+def _build_sqs_event(uri_reference: str, aws_region: str) -> dict:
+    return {
+        "Records": [
+            {
+                "messageId": "e2e-1",
+                "receiptHandle": "e2e-rh",
+                "body": json.dumps(
+                    {
+                        "Message": json.dumps(
+                            {
+                                "status": "ready",
+                                "uri_reference": uri_reference,
+                            },
+                        ),
+                    },
+                ),
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "0",
+                    "SenderId": "e2e",
+                    "ApproximateFirstReceiveTimestamp": "0",
+                },
+                "messageAttributes": {},
+                "md5OfBody": "x",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:e2e",
+                "awsRegion": aws_region,
+            },
+        ],
+    }
+
+
+def _configure_local_handler_db_env(monkeypatch) -> None:
+    """Configure DB env vars for local handler execution mode.
+
+    Set E2E_DB_HOST/E2E_DB_PORT explicitly
+    (for example 127.0.0.1:15432).
+    """
+    db_name = _require_env("DATABASE_NAME")
+    db_username = _require_env("DATABASE_USERNAME")
+    db_password_secret_name = _require_env("DB_PASSWORD_SECRET_NAME")
+    db_host = _require_env("E2E_DB_HOST")
+    db_port = _require_env("E2E_DB_PORT")
+
+    monkeypatch.setenv("DATABASE_NAME", db_name)
+    monkeypatch.setenv("DATABASE_USERNAME", db_username)
+    monkeypatch.setenv("DB_PASSWORD_SECRET_NAME", db_password_secret_name)
+    monkeypatch.setenv("DATABASE_HOSTNAME", db_host)
+    monkeypatch.setenv("DATABASE_PORT", db_port)
+
+
+def _configure_enrichment_handler_env(monkeypatch, cfg: E2EConfig) -> None:
+    monkeypatch.setenv("API_SECRET_NAME", cfg.api_secret_name)
+    monkeypatch.setenv("ENVIRONMENT", cfg.environment)
+    monkeypatch.setenv("VCITE_ENABLED", "false")
+    monkeypatch.setenv("VCITE_BUCKET", cfg.vcite_bucket)
+    monkeypatch.setenv("VCITE_ENRICHED_BUCKET", cfg.vcite_enriched_bucket)
+    monkeypatch.setenv("RULES_FILE_BUCKET", cfg.rules_bucket)
+    monkeypatch.setenv("RULES_FILE_KEY", cfg.rules_key)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", cfg.aws_region)
+
+
+def _latest_tna_enriched_date(xml: str) -> str | None:
+    dates = re.findall(r'<FRBRdate date="([^"]+)" name="tna-enriched"', xml)
+    return max(dates) if dates else None
+
+
+def _wait_for_enrichment(
+    api_endpoint: APIEndpointBaseURL,
+    uri: str,
+    username: str,
+    password: str,
+    before_xml: str,
+    timeout_seconds: int = 180,
+) -> str:
+    before_latest_enriched_date = _latest_tna_enriched_date(before_xml)
+
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        current_xml = fetch_judgment(api_endpoint, uri, username, password)
+        current_latest_enriched_date = _latest_tna_enriched_date(current_xml)
+
+        # Existing URIs can already have one enrichment tag; detect a fresh run by timestamp change.
+        if current_latest_enriched_date and current_latest_enriched_date != before_latest_enriched_date:
+            return current_xml
+
+        # Fallback for docs where timestamp extraction is unavailable.
+        if current_xml != before_xml and "<uk:tna-enrichment-engine" in current_xml:
+            return current_xml
+        time.sleep(5)
+
+    pytest.fail(
+        f"Timed out waiting for enrichment result for {uri}. "
+        "Expected tna-enriched timestamp (or document XML) to change.",
+    )
+
+
+def _wait_for_judgment_fetchable(
+    api_endpoint: APIEndpointBaseURL,
+    uri: str,
+    username: str,
+    password: str,
+    timeout_seconds: int = 60,
+) -> None:
+    """Wait briefly for Priv API lookup to observe a newly seeded fixture."""
+    last_error: RuntimeError | None = None
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            fetch_judgment(api_endpoint, uri, username, password)
+            return
+        except RuntimeError as exc:
+            last_error = exc
+            time.sleep(3)
+    pytest.fail(
+        f"Timed out waiting for Priv API to fetch seeded document at judgment/{uri}. Last Priv API error: {last_error}",
+    )
+
+
+def _trigger_enrichment(monkeypatch, cfg: E2EConfig) -> None:
+    if cfg.trigger_mode == "sqs":
+        queue_url = _get_queue_url(cfg.aws_region)
+        _send_enrichment_message(cfg.aws_region, queue_url, cfg.uri)
+        return
+
+    if cfg.trigger_mode == "local_handler":
+        _configure_local_handler_db_env(monkeypatch)
+        handler(_build_sqs_event(cfg.uri, cfg.aws_region), None)
+        return
+
+    pytest.skip("Invalid E2E_TRIGGER_MODE. Use 'sqs' or 'local_handler'.")
+
+
+@pytest.mark.e2e
+def test_enrichment_lambda_triggers_and_updates_marklogic(monkeypatch):
+    if os.getenv("E2E_RUN") != "true":
+        pytest.skip("Set E2E_RUN=true to run E2E tests")
+
+    cfg = E2EConfig.from_env()
+    _configure_enrichment_handler_env(monkeypatch, cfg)
+
+    try:
+        fixture_was_created = False
+        if cfg.seed_if_missing:
+            fixture_was_created = _seed_fixture_document_from_repo_xml(cfg.uri)
+
+        username, password = _resolve_api_credentials_from_secret(cfg.api_secret_name, cfg.aws_region)
+        if fixture_was_created:
+            _wait_for_judgment_fetchable(cfg.api_endpoint, cfg.uri, username, password)
+
+        before_xml = fetch_judgment(cfg.api_endpoint, cfg.uri, username, password)
+
+        _trigger_enrichment(monkeypatch, cfg)
+
+        after_xml = _wait_for_enrichment(
+            cfg.api_endpoint,
+            cfg.uri,
+            username,
+            password,
+            before_xml,
+            cfg.timeout_seconds,
+        )
+        assert "<akomaNtoso" in after_xml
+        assert "<uk:tna-enrichment-engine" in after_xml
+        assert after_xml != before_xml
+    finally:
+        if fixture_was_created:
+            _delete_fixture_document_if_created(cfg.uri, fixture_was_created)
+        elif cfg.should_restore:
+            try:
+                lock_judgment(cfg.api_endpoint, cfg.uri, username, password)
+                patch_judgment(cfg.api_endpoint, cfg.uri, before_xml, username, password)
+            except RuntimeError as exc:
+                # Do not mask enrichment result with restore races on shared docs.
+                if "content hash" in str(exc).lower():
+                    LOGGER.warning(
+                        "Skipping restore for %s due to content hash mismatch in shared environment: %s",
+                        cfg.uri,
+                        exc,
+                    )
+                else:
+                    raise

--- a/test_files/ewca_civ_2025_673-enriched.xml
+++ b/test_files/ewca_civ_2025_673-enriched.xml
@@ -48,7 +48,7 @@
 				<uk:number>673</uk:number>
 				<uk:cite>[2025] EWCA Civ 673</uk:cite>
 				<uk:parser>0.26.21</uk:parser>
-				<uk:hash>4a8f1887c367dbef7f627fea7587246ba67ab9e692c44edf9c31d6a35e9badd0</uk:hash>
+				<uk:hash>ec73392c9542a95c9d2658f24cd364a7b32ab86ec3e44cf6b4ac0321dbdc3249</uk:hash>
 				<uk:tna-enrichment-engine xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">7.3.0</uk:tna-enrichment-engine>
 			</proprietary>
 			<presentation source="#">

--- a/test_files/ewca_civ_2025_673-original.xml
+++ b/test_files/ewca_civ_2025_673-original.xml
@@ -72,7 +72,7 @@
                 <uk:number xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">673</uk:number>
                 <uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2025] EWCA Civ 673</uk:cite>
                 <uk:parser xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">0.26.21</uk:parser>
-                <uk:hash xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">4a8f1887c367dbef7f627fea7587246ba67ab9e692c44edf9c31d6a35e9badd0</uk:hash>
+                <uk:hash xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">ec73392c9542a95c9d2658f24cd364a7b32ab86ec3e44cf6b4ac0321dbdc3249</uk:hash>
             </proprietary>
             <presentation source="#">
                 <html:style xmlns:html="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
## Changes in this PR:

- Fix hash of xml test fixtures
- Full enrichment e2e test which runs after staging deploys

Have run in both local_handler (with ssm port forwarding to access db) and sqs modes from my local machine against staging and tests pass. You see the document get created, locked and then enriched, and then deleted.

### Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCLC-1833