### PR TITLE
Fix E2E test credential leakage and overriden env vars in pytest e2e tests in GitHub Actions

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -13,9 +13,9 @@ AWS_REGION=eu-west-2
 # Queue name for sqs trigger mode
 SQS_ENRICHMENT_QUEUE_NAME=
 
-# API access (combined secret with username/password)
+# API endpoint and access (combined secret with username/password)
+API_ENDPOINT=https://api.staging.caselaw.nationalarchives.gov.uk/
 API_SECRET_NAME=
-ENVIRONMENT=staging
 
 # Lambda runtime resources
 RULES_FILE_BUCKET=

--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -13,9 +13,15 @@ AWS_REGION=eu-west-2
 # Queue name for sqs trigger mode
 SQS_ENRICHMENT_QUEUE_NAME=
 
-# API endpoint and access (combined secret with username/password)
-API_ENDPOINT=https://api.staging.caselaw.nationalarchives.gov.uk/
-API_SECRET_NAME=
+# API endpoint and credentials
+# In GitHub Actions (SQS mode): API_USERNAME and API_PASSWORD are fetched from GitHub Secrets
+# and exported to $GITHUB_ENV before pytest runs.
+# Locally (SQS mode): set API_USERNAME and API_PASSWORD in .env.e2e for manual testing.
+# Local handler mode: requires API_SECRET_NAME (Lambda needs access to combined secret in SM)
+API_ENDPOINT=
+API_USERNAME=
+API_PASSWORD=
+API_SECRET_NAME=  # Only required for local_handler trigger mode
 
 # Lambda runtime resources
 RULES_FILE_BUCKET=
@@ -36,9 +42,9 @@ E2E_SOURCE_XML_PATH=test_files/ewca_civ_2025_673-original.xml
 MARKLOGIC_API_CLIENT_HOST=
 # Set explicitly to true or false.
 MARKLOGIC_USE_HTTPS=false
-# Default: reuses API_SECRET_NAME above for fixture-seeding credentials.
+# Fixture-seeding credentials.
+# Default: reuses API_USERNAME and API_PASSWORD above.
 # Only set these if fixture-seeding credentials are different:
-# MARKLOGIC_SECRET_NAME=
 # MARKLOGIC_USERNAME=
 # MARKLOGIC_PASSWORD=
 

--- a/.github/workflows/cd_deploy_staging_then_prod.yml
+++ b/.github/workflows/cd_deploy_staging_then_prod.yml
@@ -25,6 +25,7 @@ jobs:
       workspace: tna-staging
       app_env: staging
       vcite_enabled: ${{ secrets.VCITE_ENABLED }}
+      api_endpoint: ${{ secrets.API_ENDPOINT }}
       api_username: ${{ secrets.API_USERNAME }}
       api_password: ${{ secrets.API_PASSWORD }}
       sparql_username: ${{ secrets.SPARQL_USERNAME }}
@@ -71,8 +72,8 @@ jobs:
           E2E_RESTORE_ORIGINAL: "false"
           E2E_TIMEOUT_SECONDS: "300"
           E2E_URI: ${{ secrets.E2E_HEALTHCHECK_URI }}
+          API_ENDPOINT: https://api.staging.caselaw.nationalarchives.gov.uk/
           AWS_REGION: eu-west-2
-          ENVIRONMENT: staging
           API_SECRET_NAME: ${{ secrets.E2E_API_SECRET_NAME }}
           SQS_ENRICHMENT_QUEUE_NAME: tna-s3-tna-staging-enrichment-queue
           RULES_FILE_BUCKET: staging-tna-s3-tna-sg-rules-bucket
@@ -93,6 +94,7 @@ jobs:
   #     workspace: tna-prod
   #     app_env: production
   #     vcite_enabled: ${{ secrets.VCITE_ENABLED }}
+  #     api_endpoint: ${{ secrets.API_ENDPOINT }}
   #     api_username: ${{ secrets.API_USERNAME }}
   #     api_password: ${{ secrets.API_PASSWORD }}
   #     sparql_username: ${{ secrets.SPARQL_USERNAME }}

--- a/.github/workflows/cd_deploy_staging_then_prod.yml
+++ b/.github/workflows/cd_deploy_staging_then_prod.yml
@@ -72,9 +72,10 @@ jobs:
           E2E_RESTORE_ORIGINAL: "false"
           E2E_TIMEOUT_SECONDS: "300"
           E2E_URI: ${{ secrets.E2E_HEALTHCHECK_URI }}
-          API_ENDPOINT: https://api.staging.caselaw.nationalarchives.gov.uk/
+          API_ENDPOINT: ${{ secrets.API_ENDPOINT }}
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
           AWS_REGION: eu-west-2
-          API_SECRET_NAME: ${{ secrets.E2E_API_SECRET_NAME }}
           SQS_ENRICHMENT_QUEUE_NAME: tna-s3-tna-staging-enrichment-queue
           RULES_FILE_BUCKET: staging-tna-s3-tna-sg-rules-bucket
           RULES_FILE_KEY: citation_patterns.jsonl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
       workspace: tna-staging
       app_env: staging
       vcite_enabled: ${{ secrets.VCITE_ENABLED }}
+      api_endpoint: ${{ secrets.API_ENDPOINT }}
       api_username: ${{ secrets.API_USERNAME }}
       api_password: ${{ secrets.API_PASSWORD }}
       sparql_username: ${{ secrets.SPARQL_USERNAME }}
@@ -203,6 +204,7 @@ jobs:
       workspace: tna-prod
       app_env: production
       vcite_enabled: ${{ secrets.VCITE_ENABLED }}
+      api_endpoint: ${{ secrets.API_ENDPOINT }}
       api_username: ${{ secrets.API_USERNAME }}
       api_password: ${{ secrets.API_PASSWORD }}
       sparql_username: ${{ secrets.SPARQL_USERNAME }}

--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -15,6 +15,8 @@ on:
         required: true
       vcite_enabled:
         required: true
+      api_endpoint:
+        required: true
       api_username:
         required: true
       api_password:
@@ -77,6 +79,7 @@ jobs:
       - name: "Terraform Phase 1: Create ECR Repositories"
         env:
           TF_VAR_vcite_enabled: ${{ secrets.vcite_enabled }}
+          TF_VAR_api_endpoint: ${{ secrets.api_endpoint }}
           TF_VAR_api_username: ${{ secrets.api_username }}
           TF_VAR_api_password: ${{ secrets.api_password }}
           TF_VAR_sparql_username: ${{ secrets.sparql_username }}
@@ -208,6 +211,7 @@ jobs:
       - name: "Terraform Phase 2: Deploy Complete Infrastructure"
         env:
           TF_VAR_vcite_enabled: ${{ secrets.vcite_enabled }}
+          TF_VAR_api_endpoint: ${{ secrets.api_endpoint }}
           TF_VAR_api_username: ${{ secrets.api_username }}
           TF_VAR_api_password: ${{ secrets.api_password }}
           TF_VAR_sparql_username: ${{ secrets.sparql_username }}

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -17,6 +17,8 @@ on:
         required: true
       vcite_enabled:
         required: true
+      api_endpoint:
+        required: true
       api_username:
         required: true
       api_password:
@@ -72,6 +74,7 @@ jobs:
         id: run_terraform_plan
         env:
           TF_VAR_vcite_enabled: ${{ secrets.vcite_enabled }}
+          TF_VAR_api_endpoint: ${{ secrets.api_endpoint }}
           TF_VAR_api_username: ${{ secrets.api_username }}
           TF_VAR_api_password: ${{ secrets.api_password }}
           TF_VAR_sparql_username: ${{ secrets.sparql_username }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: v1.108.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_validate
 
   - repo: https://github.com/terraform-docs/terraform-docs
     rev: v0.21.0

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ There is an opt-in E2E test at `src/tests/end_to_end_tests/test_marklogic_e2e.py
 
 Prerequisite: your machine/runner must have network access to the target MarkLogic/API endpoints used by this test (including fixture seed/delete checks). For TNA staging, this typically means DXW VPN access.
 
+#### Credential handling
+
+- **In GitHub Actions (SQS mode)**: `API_USERNAME` and `API_PASSWORD` are fetched from GitHub Secrets and masked in logs to prevent credential leakage.
+- **Locally**: Set `API_USERNAME` and `API_PASSWORD` in `.env.e2e` for manual testing.
+- **Local handler mode**: Requires `API_SECRET_NAME` (Lambda needs access to the combined secret in Secrets Manager).
+
+#### Running the tests
+
 Use an env file so you do not need to export variables every run:
 
 ```bash
@@ -162,8 +170,9 @@ Default test runs (`make test`) exclude E2E tests by marker.
 Core required settings:
 
 - `AWS_REGION` (or `AWS_DEFAULT_REGION`)
-- `ENVIRONMENT` (for example `staging`)
-- `API_SECRET_NAME` (secret JSON with `username` and `password`)
+- `API_ENDPOINT` (endpoint URL for the Priv API)
+- `API_USERNAME` (API username)
+- `API_PASSWORD` (API password)
 - `E2E_URI` (must contain one of: `e2e`, `test-fixture`, `staging-e2e`)
 - `RULES_FILE_BUCKET`
 - `RULES_FILE_KEY`
@@ -177,15 +186,15 @@ Fixture-seeding-only settings (required only when `E2E_SEED_IF_MISSING=true`):
 
 Credential behavior for fixture seeding:
 
-- Default: fixture seeding reuses `API_SECRET_NAME` credentials from Secrets Manager.
-- Optional override secret: set `MARKLOGIC_SECRET_NAME` to use a different secret for seeding/deleting fixtures.
-- Optional explicit override: set both `MARKLOGIC_USERNAME` and `MARKLOGIC_PASSWORD`.
+- Default: fixture seeding reuses `API_USERNAME` and `API_PASSWORD` from config.
+- Optional explicit override: set both `MARKLOGIC_USERNAME` and `MARKLOGIC_PASSWORD` to use different credentials for seeding/deleting fixtures.
   - If one is set without the other, the test skips with a clear error.
+- Note: `API_SECRET_NAME` is only required for `local_handler` mode (Lambda needs access to SM for combined secret).
 
 Trigger modes:
 
-- `E2E_TRIGGER_MODE=sqs`: send message to the environment queue (tests deployed lambda path)
-- `E2E_TRIGGER_MODE=local_handler`: call local `handler(...)` with real environment resources
+- `E2E_TRIGGER_MODE=sqs`: send message to the environment queue (tests deployed lambda path). This is the primary CI/CD flow; credentials come from `API_USERNAME`/`API_PASSWORD`.
+- `E2E_TRIGGER_MODE=local_handler`: call local `handler(...)` with real environment resources. Requires `API_SECRET_NAME` to be set so Lambda can fetch combined credentials from Secrets Manager.
 
 `local_handler` mode also requires:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,4 @@
 pythonpath = src
 addopts = -p no:socket
 markers =
-    e2e: runs end-to-end tests against real AWS/MarkLogic resources
-env =
-    SOURCE_BUCKET=TEST_SOURCE_BUCKET
-    API_USERNAME=TEST_USERNAME
-    API_PASSWORD=TEST_PASSWORD
-    ENVIRONMENT=TEST_ENVIRONMENT
+    staging_e2e: runs staging end-to-end tests against real AWS/MarkLogic resources

--- a/src/lambdas/enrichment_lambda/index.py
+++ b/src/lambdas/enrichment_lambda/index.py
@@ -34,11 +34,6 @@ def _is_test_event(record: dict[str, Any]) -> bool:
     return "Event" in record and record["Event"] == "s3:TestEvent"
 
 
-def _get_api_endpoint(environment: str) -> APIEndpointBaseURL:
-    subdomain = "api.staging" if environment == "staging" else "api"
-    return APIEndpointBaseURL(f"https://{subdomain}.caselaw.nationalarchives.gov.uk/")
-
-
 def _process_vcite_callback_event(
     event: dict[str, Any],
     api_endpoint: APIEndpointBaseURL,
@@ -109,7 +104,6 @@ def handler(event: dict[str, Any], context: LambdaContext) -> None:
     api_username: str
     api_password: str
     api_username, api_password = _resolve_api_credentials()
-    environment: str = validate_env_variable("ENVIRONMENT")
     vcite_enabled: bool = validate_env_variable("VCITE_ENABLED") == "true"
 
     # Environment variables only for sqs enrichment event
@@ -120,9 +114,9 @@ def handler(event: dict[str, Any], context: LambdaContext) -> None:
     # Environment variable only needed for vCite callback event
     vcite_enriched_bucket: str = validate_env_variable("VCITE_ENRICHED_BUCKET")
 
-    LOGGER.info("Enrichment Lambda triggered, environment: %s", environment)
+    api_endpoint = APIEndpointBaseURL(validate_env_variable("API_ENDPOINT"))
 
-    api_endpoint = _get_api_endpoint(environment)
+    LOGGER.info("Enrichment Lambda triggered, endpoint: %s", api_endpoint)
 
     try:
         # May delete this block if we don't want to support vCite callback events in the enrichment lambda

--- a/src/tests/end_to_end_tests/test_marklogic_e2e.py
+++ b/src/tests/end_to_end_tests/test_marklogic_e2e.py
@@ -36,7 +36,6 @@ load_dotenv(PROJECT_ROOT / ".env.e2e", override=True)
 @dataclass(frozen=True)
 class E2EConfig:
     aws_region: str
-    environment: str
     api_endpoint: APIEndpointBaseURL
     uri: str
     api_secret_name: str
@@ -64,7 +63,6 @@ class E2EConfig:
     @classmethod
     def from_env(cls) -> "E2EConfig":
         aws_region = _require_any_env("AWS_REGION", "AWS_DEFAULT_REGION")
-        environment = _require_env("ENVIRONMENT")
         uri = _require_env("E2E_URI")
         trigger_mode = os.getenv("E2E_TRIGGER_MODE", "sqs").lower()
         if trigger_mode not in {"sqs", "local_handler"}:
@@ -110,8 +108,7 @@ class E2EConfig:
 
         return cls(
             aws_region=aws_region,
-            environment=environment,
-            api_endpoint=_get_api_endpoint(environment),
+            api_endpoint=APIEndpointBaseURL(_require_env("API_ENDPOINT")),
             uri=uri,
             api_secret_name=_require_env("API_SECRET_NAME"),
             rules_bucket=_require_env("RULES_FILE_BUCKET"),
@@ -234,11 +231,6 @@ def _resolve_api_credentials_from_secret(secret_name: str, aws_region: str) -> t
     return secret_json["username"], secret_json["password"]
 
 
-def _get_api_endpoint(environment: str) -> APIEndpointBaseURL:
-    subdomain = "api.staging" if environment == "staging" else "api"
-    return APIEndpointBaseURL(f"https://{subdomain}.caselaw.nationalarchives.gov.uk/")
-
-
 def _get_queue_url(cfg: E2EConfig) -> str:
     if not cfg.sqs_queue_name:
         pytest.fail("SQS_ENRICHMENT_QUEUE_NAME is required for sqs trigger mode")
@@ -324,7 +316,7 @@ def _configure_local_handler_db_env(monkeypatch, cfg: E2EConfig) -> None:
 
 def _configure_enrichment_handler_env(monkeypatch, cfg: E2EConfig) -> None:
     monkeypatch.setenv("API_SECRET_NAME", cfg.api_secret_name)
-    monkeypatch.setenv("ENVIRONMENT", cfg.environment)
+    monkeypatch.setenv("API_ENDPOINT", str(cfg.api_endpoint))
     monkeypatch.setenv("VCITE_ENABLED", "false")
     monkeypatch.setenv("VCITE_BUCKET", cfg.vcite_bucket)
     monkeypatch.setenv("VCITE_ENRICHED_BUCKET", cfg.vcite_enriched_bucket)

--- a/src/tests/end_to_end_tests/test_marklogic_e2e.py
+++ b/src/tests/end_to_end_tests/test_marklogic_e2e.py
@@ -37,9 +37,11 @@ load_dotenv(PROJECT_ROOT / ".env.e2e", override=True)
 class E2EConfig:
     aws_region: str
     api_endpoint: APIEndpointBaseURL
+    api_username: str
+    api_password: str
     uri: str
-    api_secret_name: str
     rules_bucket: str
+    api_secret_name: str | None
     rules_key: str
     vcite_bucket: str
     vcite_enriched_bucket: str
@@ -93,6 +95,10 @@ class E2EConfig:
                 "Both MARKLOGIC_USERNAME and MARKLOGIC_PASSWORD must be set when using explicit credentials",
             )
 
+        api_username = _require_env("API_USERNAME")
+        api_password = _require_env("API_PASSWORD")
+        api_secret_name = os.getenv("API_SECRET_NAME")  # Optional, only used for local_handler
+
         if trigger_mode == "local_handler":
             database_name = _require_env("DATABASE_NAME")
             database_username = _require_env("DATABASE_USERNAME")
@@ -110,7 +116,6 @@ class E2EConfig:
             aws_region=aws_region,
             api_endpoint=APIEndpointBaseURL(_require_env("API_ENDPOINT")),
             uri=uri,
-            api_secret_name=_require_env("API_SECRET_NAME"),
             rules_bucket=_require_env("RULES_FILE_BUCKET"),
             rules_key=_require_env("RULES_FILE_KEY"),
             vcite_bucket=_require_env("VCITE_BUCKET"),
@@ -126,11 +131,14 @@ class E2EConfig:
             marklogic_secret_name=marklogic_secret_name,
             marklogic_username=marklogic_username,
             marklogic_password=marklogic_password,
+            api_username=api_username,
+            api_password=api_password,
             database_name=database_name,
             database_username=database_username,
             db_password_secret_name=db_password_secret_name,
             e2e_db_host=e2e_db_host,
             e2e_db_port=e2e_db_port,
+            api_secret_name=api_secret_name,
         )
 
 
@@ -149,33 +157,16 @@ def _require_any_env(*names: str) -> str:
     pytest.fail(f"Missing required env var for E2E: one of {', '.join(names)}")
 
 
-def _resolve_marklogic_fixture_credentials(cfg: E2EConfig) -> tuple[str, str]:
-    """Resolve fixture-seeding credentials.
-
-    Defaults to API_SECRET_NAME unless MARKLOGIC_SECRET_NAME is explicitly set.
-    MARKLOGIC_USERNAME/MARKLOGIC_PASSWORD may be used as explicit overrides.
-    """
-    explicit_username = cfg.marklogic_username
-    explicit_password = cfg.marklogic_password
-
-    if explicit_username or explicit_password:
-        return explicit_username, explicit_password
-
-    secret_name = cfg.marklogic_secret_name or cfg.api_secret_name
-    return _resolve_api_credentials_from_secret(secret_name, cfg.aws_region)
-
-
 def _create_marklogic_client_for_fixture(cfg: E2EConfig) -> MarklogicApiClient:
     if not cfg.marklogic_api_client_host or cfg.marklogic_use_https is None:
         pytest.fail(
             "Fixture seeding requires MARKLOGIC_API_CLIENT_HOST and MARKLOGIC_USE_HTTPS",
         )
-    username, password = _resolve_marklogic_fixture_credentials(cfg)
 
     return MarklogicApiClient(
         host=cfg.marklogic_api_client_host,
-        username=username,
-        password=password,
+        username=cfg.api_username,
+        password=cfg.api_password,
         use_https=cfg.marklogic_use_https,
         user_agent=f"ds-caselaw-data-enrichment-service/e2e {DEFAULT_USER_AGENT}",
     )
@@ -222,13 +213,6 @@ def _delete_fixture_document_if_created(
         return
     marklogic_client = _create_marklogic_client_for_fixture(cfg)
     marklogic_client.delete_judgment(DocumentURIString(target_uri))
-
-
-def _resolve_api_credentials_from_secret(secret_name: str, aws_region: str) -> tuple[str, str]:
-    sm = boto3.client("secretsmanager", region_name=aws_region)
-    secret_string = sm.get_secret_value(SecretId=secret_name)["SecretString"]
-    secret_json = json.loads(secret_string)
-    return secret_json["username"], secret_json["password"]
 
 
 def _get_queue_url(cfg: E2EConfig) -> str:
@@ -315,7 +299,6 @@ def _configure_local_handler_db_env(monkeypatch, cfg: E2EConfig) -> None:
 
 
 def _configure_enrichment_handler_env(monkeypatch, cfg: E2EConfig) -> None:
-    monkeypatch.setenv("API_SECRET_NAME", cfg.api_secret_name)
     monkeypatch.setenv("API_ENDPOINT", str(cfg.api_endpoint))
     monkeypatch.setenv("VCITE_ENABLED", "false")
     monkeypatch.setenv("VCITE_BUCKET", cfg.vcite_bucket)
@@ -323,6 +306,9 @@ def _configure_enrichment_handler_env(monkeypatch, cfg: E2EConfig) -> None:
     monkeypatch.setenv("RULES_FILE_BUCKET", cfg.rules_bucket)
     monkeypatch.setenv("RULES_FILE_KEY", cfg.rules_key)
     monkeypatch.setenv("AWS_DEFAULT_REGION", cfg.aws_region)
+    # API_SECRET_NAME required only for local_handler mode (Lambda needs SM access)
+    if cfg.trigger_mode == "local_handler" and cfg.api_secret_name:
+        monkeypatch.setenv("API_SECRET_NAME", cfg.api_secret_name)
 
 
 def _latest_tna_enriched_date(xml: str) -> str | None:
@@ -406,19 +392,18 @@ def test_enrichment_lambda_triggers_and_updates_marklogic(monkeypatch):
         if cfg.seed_if_missing:
             fixture_was_created = _seed_fixture_document_from_repo_xml(cfg, cfg.uri)
 
-        username, password = _resolve_api_credentials_from_secret(cfg.api_secret_name, cfg.aws_region)
         if fixture_was_created:
-            _wait_for_judgment_fetchable(cfg.api_endpoint, cfg.uri, username, password)
+            _wait_for_judgment_fetchable(cfg.api_endpoint, cfg.uri, cfg.api_username, cfg.api_password)
 
-        before_xml = fetch_judgment(cfg.api_endpoint, cfg.uri, username, password)
+        before_xml = fetch_judgment(cfg.api_endpoint, cfg.uri, cfg.api_username, cfg.api_password)
 
         _trigger_enrichment(monkeypatch, cfg)
 
         after_xml = _wait_for_enrichment(
             cfg.api_endpoint,
             cfg.uri,
-            username,
-            password,
+            cfg.api_username,
+            cfg.api_password,
             before_xml,
             cfg.timeout_seconds,
         )
@@ -430,8 +415,8 @@ def test_enrichment_lambda_triggers_and_updates_marklogic(monkeypatch):
             _delete_fixture_document_if_created(cfg, cfg.uri, fixture_was_created)
         elif cfg.should_restore:
             try:
-                lock_judgment(cfg.api_endpoint, cfg.uri, username, password)
-                patch_judgment(cfg.api_endpoint, cfg.uri, before_xml, username, password)
+                lock_judgment(cfg.api_endpoint, cfg.uri, cfg.api_username, cfg.api_password)
+                patch_judgment(cfg.api_endpoint, cfg.uri, before_xml, cfg.api_username, cfg.api_password)
             except RuntimeError as exc:
                 # Do not mask enrichment result with restore races on shared docs.
                 if "content hash" in str(exc).lower():

--- a/src/tests/lambda_tests/enrichment_lambda/test_index.py
+++ b/src/tests/lambda_tests/enrichment_lambda/test_index.py
@@ -39,7 +39,7 @@ class TestHandler:
     ):
         env_values = {
             "API_SECRET_NAME": "api-credentials-secret",
-            "ENVIRONMENT": "staging",
+            "API_ENDPOINT": "staging-api-endpoint",
             "RULES_FILE_BUCKET": "rules-bucket",
             "RULES_FILE_KEY": "rules-key",
             "VCITE_BUCKET": "vcite-tna-files",
@@ -91,7 +91,7 @@ class TestHandler:
         assert mock_enrich_judgment.call_count == 1
         call_args = mock_enrich_judgment.call_args
         assert call_args[0][0] == "ewhc/ch/2023/257"  # uri_reference
-        assert call_args[0][1] == "https://api.staging.caselaw.nationalarchives.gov.uk/"  # endpoint
+        assert call_args[0][1] == "staging-api-endpoint"  # endpoint
         assert call_args[0][2] == "api-user"  # api_username
         assert call_args[0][3] == "api-credential"  # api_password
         assert call_args[0][4] == [
@@ -111,7 +111,7 @@ class TestHandler:
         bucket_name = "production-tna-s3-tna-sg-vcite-enriched-bucket"
         env_values = {
             "API_SECRET_NAME": "api-credentials-secret",
-            "ENVIRONMENT": "production",
+            "API_ENDPOINT": "staging-api-endpoint",
             "RULES_FILE_BUCKET": "rules-bucket",
             "RULES_FILE_KEY": "rules-key",
             "VCITE_BUCKET": "vcite-tna-files",
@@ -157,7 +157,7 @@ class TestHandler:
         index.handler(event, None)
 
         called_endpoint, called_doc_uri, called_xml, called_user, called_password = mock_patch.call_args.args
-        assert called_endpoint == "https://api.caselaw.nationalarchives.gov.uk/"
+        assert called_endpoint == "staging-api-endpoint"
         assert called_doc_uri == "ewhc/ch/2023/257"
         assert "<akomaNtoso" in called_xml
         assert called_user == "api-user"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -29,6 +29,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_api_endpoint"></a> [api\_endpoint](#input\_api\_endpoint) | Base API endpoint used by enrichment lambda | `string` | n/a | yes |
 | <a name="input_api_password"></a> [api\_password](#input\_api\_password) | API password to store in AWS Secrets Manager | `string` | n/a | yes |
 | <a name="input_api_username"></a> [api\_username](#input\_api\_username) | API username to store in AWS Secrets Manager | `string` | n/a | yes |
 | <a name="input_app_env"></a> [app\_env](#input\_app\_env) | Common prefix for all Terraform created resources | `string` | `"staging"` | no |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,6 +31,7 @@ module "lambda_s3" {
   postgress_master_password_secret_id = module.data.aurora_postgress_master_password["main"]
   postgress_hostname                  = module.data.aurora_postgress_hostname["main"]
   vcite_enabled                       = var.vcite_enabled
+  api_endpoint                        = var.api_endpoint
   api_username                        = var.api_username
   api_password                        = var.api_password
   sparql_username                     = var.sparql_username

--- a/terraform/modules/lambda_s3/lambda.tf
+++ b/terraform/modules/lambda_s3/lambda.tf
@@ -182,7 +182,7 @@ module "lambda-enrichment" {
 
   environment_variables = {
     API_SECRET_NAME         = aws_secretsmanager_secret.api_credentials.name
-    ENVIRONMENT             = local.environment
+    API_ENDPOINT            = local.api_endpoint
     DATABASE_NAME           = "rules"
     DATABASE_USERNAME       = "root"
     DATABASE_PORT           = "5432"

--- a/terraform/modules/lambda_s3/locals.tf
+++ b/terraform/modules/lambda_s3/locals.tf
@@ -1,7 +1,8 @@
 locals {
-  name        = "tna-s3-${var.name}"
-  region      = var.aws_region
-  environment = var.environment
+  name         = "tna-s3-${var.name}"
+  region       = var.aws_region
+  environment  = var.environment
+  api_endpoint = var.api_endpoint
   tags = {
     Environment = var.environment
     Project     = "TNA-enrichment"

--- a/terraform/modules/lambda_s3/variables.tf
+++ b/terraform/modules/lambda_s3/variables.tf
@@ -24,6 +24,11 @@ variable "name" {
 variable "environment" {
   type = string
 }
+
+variable "api_endpoint" {
+  type = string
+}
+
 variable "source_bucket_folder" {
   type    = string
   default = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,6 +17,11 @@ variable "vcite_enabled" {
   description = "Enable vCite processing and upload in enrichment lambda"
 }
 
+variable "api_endpoint" {
+  type        = string
+  description = "Base API endpoint used by enrichment lambda"
+}
+
 variable "api_username" {
   type        = string
   description = "API username to store in AWS Secrets Manager"


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-1833

**Problem**
API credentials fetched from AWS Secrets Manager at runtime in E2E tests were not masked by GitHub Actions, risking [credential leaks in workflow logs.
](https://github.com/nationalarchives/ds-caselaw-data-enrichment-service/actions/runs/29027474266/job/86152451840)Also pytest.ini was overriding certain environment variables across all tests including the e2e test, in particular ENVIRONMENT.

(Don't worry - we rotated the leaked password immediately, and will not set it until confirmed that this is masked in the next run)


<img width="1104" height="572" alt="Screenshot 2026-07-09 at 16 04 55" src="https://github.com/user-attachments/assets/b37c7c8b-50af-4c27-a127-192d2b678430" />

**Solution**
- E2E tests now use API_USERNAME and API_PASSWORD directly from GitHub Secrets so workflow masks credentials and exports to $GITHUB_ENV before pytest runs (by default)

**Key changes**
- Replace SM fetch with direct GitHub Secrets reference + masking
- Simplify credential handling, remove SM fetch function
- Update docs to clarify credential flow by mode (SQS vs local_handler)

NOTE: long term we will move towards Marklogic External IDP, JWT based auth to limit credential leak risks.