### PR TITLE
Deploy latest images to corresponding lambda in deployment workflow

### DIFF
--- a/.github/workflows/deploy_single_environment.yml
+++ b/.github/workflows/deploy_single_environment.yml
@@ -166,8 +166,15 @@ jobs:
 
           aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com
 
-          docker tag ${{ matrix.lambda }}:local ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/${{ matrix.ecr_repo }}-${{ secrets.app_env }}:latest
-          docker push ${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/${{ matrix.ecr_repo }}-${{ secrets.app_env }}:latest
+          IMAGE_REPO="${{ secrets.account_id }}.dkr.ecr.eu-west-2.amazonaws.com/${{ matrix.ecr_repo }}-${{ secrets.app_env }}"
+          IMAGE_TAG="${{ github.sha }}"
+
+          docker tag ${{ matrix.lambda }}:local ${IMAGE_REPO}:${IMAGE_TAG}
+          docker push ${IMAGE_REPO}:${IMAGE_TAG}
+
+          # Keep latest for operational convenience while deployments use immutable SHA tags.
+          docker tag ${{ matrix.lambda }}:local ${IMAGE_REPO}:latest
+          docker push ${IMAGE_REPO}:latest
 
   deploy-terraform-phase-2:
     name: Deploy infrastructure
@@ -221,4 +228,6 @@ jobs:
           set -o pipefail
           cd terraform
           terraform workspace select ${{ secrets.workspace }}
-          terraform apply --auto-approve -no-color -var "app_env=${{ secrets.app_env }}"
+          terraform apply --auto-approve -no-color \
+            -var "app_env=${{ secrets.app_env }}" \
+            -var "container_image_tag=${{ github.sha }}"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -34,6 +34,7 @@ No resources.
 | <a name="input_api_username"></a> [api\_username](#input\_api\_username) | API username to store in AWS Secrets Manager | `string` | n/a | yes |
 | <a name="input_app_env"></a> [app\_env](#input\_app\_env) | Common prefix for all Terraform created resources | `string` | `"staging"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | n/a | `string` | `"sg"` | no |
+| <a name="input_container_image_tag"></a> [container\_image\_tag](#input\_container\_image\_tag) | Container image tag used by Lambda image-based deployments | `string` | `"latest"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to deploy to | `string` | `"eu-west-2"` | no |
 | <a name="input_sparql_password"></a> [sparql\_password](#input\_sparql\_password) | SPARQL password to store in AWS Secrets Manager | `string` | n/a | yes |
 | <a name="input_sparql_username"></a> [sparql\_username](#input\_sparql\_username) | SPARQL username to store in AWS Secrets Manager | `string` | n/a | yes |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,6 +30,7 @@ module "lambda_s3" {
 
   postgress_master_password_secret_id = module.data.aurora_postgress_master_password["main"]
   postgress_hostname                  = module.data.aurora_postgress_hostname["main"]
+  container_image_tag                 = var.container_image_tag
   vcite_enabled                       = var.vcite_enabled
   api_endpoint                        = var.api_endpoint
   api_username                        = var.api_username

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,6 +12,12 @@ variable "bucket_prefix" {
   default = "sg"
 }
 
+variable "container_image_tag" {
+  type        = string
+  description = "Container image tag used by Lambda image-based deployments"
+  default     = "latest"
+}
+
 variable "vcite_enabled" {
   type        = bool
   description = "Enable vCite processing and upload in enrichment lambda"


### PR DESCRIPTION
Deploy latest images to corresponding lambda in deployment workflow by tagging specific commit hash rather than relying on latest

### Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCLC-1833