### PR TITLE
Fix press summary enrichment

### DIFF
--- a/src/enrichment/replacer/make_replacements.py
+++ b/src/enrichment/replacer/make_replacements.py
@@ -98,6 +98,14 @@ def detect_reference(text: str, etype: Literal["legislation"]) -> Reference:
     return references
 
 
+def split_xml_declaration(content: str) -> tuple[str, str]:
+    match = re.match(r"\s*(<\?xml[^>]*\?>)", content)
+    if not match:
+        return "", content
+
+    return match.group(1), content[match.end() :].lstrip()
+
+
 def sanitize_judgment(file_content: DocumentAsXMLString) -> DocumentAsXMLString:
     file_content = _remove_old_enrichment_references(file_content)
 

--- a/src/lambdas/enrichment_lambda/api.py
+++ b/src/lambdas/enrichment_lambda/api.py
@@ -45,6 +45,22 @@ def lock_judgment(api_endpoint: APIEndpointBaseURL, query: str, username: str, p
     LOGGER.info("Judgment locked successfully")
 
 
+def unlock_judgment(api_endpoint: APIEndpointBaseURL, query: str, username: str, password: str) -> None:
+    http = urllib3.PoolManager()
+    url = f"{api_endpoint}lock/{query}"
+    headers = urllib3.make_headers(basic_auth=username + ":" + password)
+    response = http.request("DELETE", url, headers=headers)
+
+    if response.status not in (200, 204):
+        message = (
+            f"Failed to unlock judgment from {url}, status code: {response.status}, response: {response.data.decode()}"
+        )
+        LOGGER.error(message)
+        raise RuntimeError(message)
+
+    LOGGER.info("Judgment unlocked successfully")
+
+
 def patch_judgment(
     api_endpoint: APIEndpointBaseURL,
     document_uri: str,

--- a/src/lambdas/enrichment_lambda/enrich_judgment.py
+++ b/src/lambdas/enrichment_lambda/enrich_judgment.py
@@ -4,7 +4,7 @@ import logging
 
 import boto3
 
-from lambdas.enrichment_lambda.api import fetch_judgment, lock_judgment, patch_judgment
+from lambdas.enrichment_lambda.api import fetch_judgment, lock_judgment, patch_judgment, unlock_judgment
 from lambdas.enrichment_lambda.enrich_xml import enrich_xml
 from utils.custom_types import APIEndpointBaseURL
 
@@ -26,20 +26,35 @@ def enrich_judgment(
     LOGGER.info("Locking judgment: %s", uri_reference)
     lock_judgment(api_endpoint, uri_reference, api_username, api_password)
 
-    LOGGER.info("Fetching judgment from API endpoint: %s", api_endpoint)
-    xml_content = fetch_judgment(api_endpoint, uri_reference, api_username, api_password)
+    judgment_locked = True
+    try:
+        LOGGER.info("Fetching judgment from API endpoint: %s", api_endpoint)
+        xml_content = fetch_judgment(api_endpoint, uri_reference, api_username, api_password)
 
-    LOGGER.info("Enriching judgment content for: %s", uri_reference)
-    enriched_xml = enrich_xml(xml_content, pattern_list, enrichment_version="7.4.0")
+        LOGGER.info("Enriching judgment content for: %s", uri_reference)
+        enriched_xml = enrich_xml(xml_content, pattern_list, enrichment_version="7.4.0")
 
-    if vcite_enabled:
-        # May delete this block if we don't want to support vCite callback events in the enrichment lambda
-        source_key = f"{uri_reference}.xml"
-        LOGGER.info("vCite is on; uploading XML content to vCite input bucket: %s/%s", vcite_bucket, source_key)
-        s3 = boto3.resource("s3")
-        s3.Object(vcite_bucket, source_key).put(Body=xml_content.encode("utf-8"))
-        LOGGER.info("Uploaded to vCite input for: %s", uri_reference)
-    else:
-        LOGGER.info("Patching enriched judgment back to API endpoint: %s", api_endpoint)
-        patch_judgment(api_endpoint, uri_reference, enriched_xml, api_username, api_password)
-        LOGGER.info("Successfully enriched and patched: %s", uri_reference)
+        if vcite_enabled:
+            # May delete this block if we don't want to support vCite callback events in the enrichment lambda
+            source_key = f"{uri_reference}.xml"
+            LOGGER.info("vCite is on; uploading XML content to vCite input bucket: %s/%s", vcite_bucket, source_key)
+            s3 = boto3.resource("s3")
+            s3.Object(vcite_bucket, source_key).put(Body=xml_content.encode("utf-8"))
+            LOGGER.info("Uploaded to vCite input for: %s", uri_reference)
+        else:
+            LOGGER.info("Patching enriched judgment back to API endpoint: %s", api_endpoint)
+            patch_judgment(api_endpoint, uri_reference, enriched_xml, api_username, api_password)
+            judgment_locked = False
+            LOGGER.info("Successfully enriched and patched: %s", uri_reference)
+    except Exception:
+        if judgment_locked:
+            LOGGER.warning("Unlocking judgment after failure: %s", uri_reference)
+            try:
+                unlock_judgment(api_endpoint, uri_reference, api_username, api_password)
+            except RuntimeError as unlock_exc:
+                LOGGER.error(
+                    "Failed to unlock judgment while handling error for %s: %s",
+                    uri_reference,
+                    unlock_exc,
+                )
+        raise

--- a/src/lambdas/enrichment_lambda/steps.py
+++ b/src/lambdas/enrichment_lambda/steps.py
@@ -20,6 +20,7 @@ from enrichment.replacer.make_replacements import (
     apply_replacements,
     sanitize_judgment,
     split_text_by_closing_header_tag,
+    split_xml_declaration,
 )
 from enrichment.replacer.second_stage_replacer import replace_references_by_paragraph
 from utils.custom_types import DocumentAsXMLString
@@ -162,9 +163,11 @@ def make_post_header_replacements(
     Returns:
         str: The modified legal document content with the replacement applied.
     """
+    xml_declaration, _ = split_xml_declaration(original_content)
     cleaned_file_content = sanitize_judgment(original_content)
+    _, cleaned_body = split_xml_declaration(cleaned_file_content)
 
-    pre_header, end_header_tag, post_header = split_text_by_closing_header_tag(cleaned_file_content)
+    pre_header, end_header_tag, post_header = split_text_by_closing_header_tag(DocumentAsXMLString(cleaned_body))
 
     replaced_post_header_content = apply_replacements(post_header, replacement_patterns)
     LOGGER.info("Got post-header replacement text content")
@@ -173,5 +176,8 @@ def make_post_header_replacements(
 
     # raises an lxml.etree.XMLSyntaxError if the output is not valid XML
     lxml.etree.fromstring(full_replaced_text_content.encode("utf-8"))
+
+    if xml_declaration:
+        full_replaced_text_content = f"{xml_declaration}\n{full_replaced_text_content}"
 
     return DocumentAsXMLString(full_replaced_text_content)

--- a/src/tests/fixtures/uksc-2022-14-press-summary.xml
+++ b/src/tests/fixtures/uksc-2022-14-press-summary.xml
@@ -1,0 +1,124 @@
+<akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+  <doc name="pressSummary">
+    <meta>
+      <identification source="#tna">
+	<FRBRWork>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/uksc/2022/14/press-summary/1"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/uksc/2022/14/press-summary/1"/>
+	  <FRBRdate date="2022-05-25" name="release"/>
+	  <FRBRauthor href="#uksc"/>
+	  <FRBRcountry value="GB-UKM"/>
+	  <FRBRname value="Press Summary of Competition and Markets Authority v Flynn Pharma Ltd and another Competition and Markets Authority v Pfizer Inc and another"/>
+	</FRBRWork>
+	<FRBRExpression>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2022/14/press-summary/1"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2022/14/press-summary/1"/>
+	  <FRBRdate date="2022-05-25" name="release"/>
+	  <FRBRauthor href="#uksc"/>
+	  <FRBRlanguage language="eng"/>
+	</FRBRExpression>
+	<FRBRManifestation>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2022/14/press-summary/1/data.xml"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2022/14/press-summary/1/data.xml"/>
+	  <FRBRdate date="2026-07-14T08:08:58" name="transform"/>
+	  <FRBRauthor href="#tna"/>
+	  <FRBRformat value="application/xml"/>
+	</FRBRManifestation>
+      </identification>
+      <references source="#tna">
+	<TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk" showAs="The National Archives"/>
+	<TLCOrganization eId="uksc" href="https://www.supremecourt.uk/" showAs="The Supreme Court"/>
+      </references>
+      <proprietary source="#tna">
+	<uk:court>UKSC</uk:court>
+	<uk:year>2022</uk:year>
+	<uk:summaryOf>https://caselaw.nationalarchives.gov.uk/id/uksc/2022/14</uk:summaryOf>
+	<uk:summaryOfCite>[2022] UKSC 14</uk:summaryOfCite>
+	<uk:parser>1.10.1</uk:parser>
+	<uk:hash>41a7181729d24a4a43271bcabf5bb943d743b1ca153acf816cb3bb24489e91dc</uk:hash>
+      </proprietary>
+      <presentation source="#">
+	<style xmlns="http://www.w3.org/1999/xhtml">
+#main { font-family: 'Times New Roman'; font-size: 12pt; }
+#main .Normal { font-size: 12pt; }
+#main .Heading1 { font-weight: bold; font-size: 20pt; }
+#main .Heading2 { font-weight: bold; font-size: 14pt; }
+#main .Heading3 { font-weight: bold; font-size: 17pt; }
+#main .Heading4 { font-weight: bold; font-size: 11pt; }
+#main .Heading5 { font-weight: bold; font-size: 14pt; }
+#main .Heading6 { font-style: italic; text-decoration-line: underline; text-decoration-style: solid; font-size: 13pt; }
+#main .Heading7 { font-weight: bold; font-size: 11pt; }
+#main .Date { text-align: right; font-weight: bold; font-size: 14pt; }
+#main .NoSpacing { }
+#main .CaseDetails { font-weight: bold; font-size: 16pt; }
+#main .CourtOrder { font-weight: bold; font-size: 16pt; }
+#main .Justices { font-weight: bold; font-size: 14pt; }
+#main .SubsectionHeading { font-style: italic; text-decoration-line: underline; text-decoration-style: solid; font-size: 12pt; }
+#main .SectionHeading { font-weight: bold; font-size: 14pt; }
+#main .Note { font-weight: bold; font-size: 12pt; }
+#main .PressSummary { font-weight: bold; font-size: 18pt; }
+#main .StyleJusticesNotBold { font-weight: normal; font-size: 14pt; }
+#main .StyleSubsectionHeadingNounderline { font-style: italic; text-decoration-line: none; font-size: 12pt; }
+#main .CommentText { font-size: 10pt; }
+#main .CommentSubject { font-weight: bold; font-size: 10pt; }
+#main .ListParagraph { margin-left: 0.5in; font-size: 12pt; }
+#main .JudgmentJudges { text-align: center; font-weight: bold; font-size: 17pt; }
+#main .Revision { font-size: 12pt; }
+#main .Heading1Char { font-weight: bold; font-size: 20pt; }
+#main .DateChar { font-weight: bold; font-size: 14pt; }
+#main .Heading2Char { font-weight: bold; font-size: 14pt; }
+#main .Heading3Char { font-weight: bold; font-size: 17pt; }
+#main .Heading4Char { font-weight: bold; font-size: 11pt; }
+#main .Heading5Char { font-weight: bold; font-size: 14pt; }
+#main .Heading6Char { font-style: italic; text-decoration-line: underline; text-decoration-style: solid; font-size: 13pt; }
+#main .Heading7Char { font-weight: bold; font-size: 11pt; }
+#main .Hyperlink { text-decoration-line: underline; text-decoration-style: solid; color: #0000FF; }
+#main .CommentReference { font-size: 8pt; }
+#main .CommentTextChar { }
+#main .CommentSubjectChar { font-weight: bold; }
+</style>
+      </presentation>
+    </meta>
+    <preface>
+      <p style="text-align:center"><img src="image1.png" style="width:84pt;height:112.5pt"/></p>
+      <p class="PressSummary"><docType style="font-size:20pt">Press Summary</docType></p>
+      <p class="Date" style="text-align:left"><docDate date="2022-05-25" refersTo="#release">25 May 2022</docDate></p>
+      <p class="JudgmentJudges" style="text-align:left"><docTitle><span style="font-size:16pt">Competition and Markets Authority (Respondent) v Flynn Pharma Ltd and another (Appellants)</span><br/><span style="font-size:16pt">Competition and Markets Authority (Respondent) v Pfizer Inc and another (Appellants)</span></docTitle></p>
+      <p class="JudgmentJudges" style="text-align:left"><neutralCitation style="font-size:16pt">[2022] UKSC 14</neutralCitation></p>
+      <p class="JudgmentJudges" style="text-align:left"><span style="font-style:italic;font-size:16pt">On appeal from: </span><ref style="font-style:italic;font-size:16pt" href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2020/617" uk:origin="parser" uk:canonical="[2020] EWCA Civ 617" uk:type="case" uk:isNeutral="true">[2020] EWCA Civ 617</ref></p>
+      <p class="Justices">Justices: <span style="font-weight:normal;font-size:12pt">Lord Hodge (Deputy President), Lord Sales, Lord Leggatt, Lord Stephens,</span><br/><span style="font-weight:normal;font-size:12pt">Lady Rose</span></p>
+    </preface>
+    <mainBody>
+      <level>
+	<heading class="SectionHeading">Background to the Appeal</heading>
+	<content>
+	  <p style="text-align:justify">The Respondent (&#8220;<span style="font-weight:bold">the CMA</span>&#8221;) is a public body tasked with investigating companies suspected of breaching competition law and penalising those found to have done so. The Appellants are both pharmaceutical companies fined by the CMA for breaches of the Competition Act 1998 in respect of the supply of prescription epilepsy drugs.</p>
+	  <p style="text-align:justify">The Appellants both appealed to the Competition Appeal Tribunal (&#8220;<span style="font-weight:bold">the CAT</span>&#8221;) challenging the CMA&#8217;s decision. The CAT allowed the appeals in part, set aside part of the CMA&#8217;s decision, and remitted the case to the CMA for reconsideration.</p>
+	  <p style="text-align:justify">The CAT also made an order that the CMA pay the Appellants a proportion of their costs of the appeal (&#8220;<span style="font-weight:bold">the CAT&#8217;s Costs Ruling</span>&#8221;). It did this under the power conferred by Rule 104(2) of the Competition Appeal Tribunal Rules 2015 (&#8220;<span style="font-weight:bold">the 2015 Rules</span>&#8221;), which states that the CAT may &#8220;<span style="font-style:italic">make any order it thinks fit in relation to the payment of costs&#8221;.</span> The Rule then lists a number of factors that the CAT may take into account when considering costs, but does not set any particular starting point or presumption as to the order the CAT should make.</p>
+	  <p style="text-align:justify">The Court of Appeal set aside the CAT&#8217;s Costs Ruling and ordered that there be no order as to costs of the appeal before the CAT. This was because the Court of Appeal considered that the CAT had disregarded a general legal principle based on a line of cases beginning with <span style="font-style:italic">Bradford Metropolitan District Council v Booth </span>[2000] 164 JP 485 (&#8220;<span style="font-style:italic;font-weight:bold">Booth</span>&#8221;) that, where there is no default position expressed in the wording of the power to award costs, the starting point is that no order for costs should be made against a public body such as the CMA when it has been unsuccessful in bringing or defending proceedings in the exercise of its statutory functions. That starting point may be departed from where there is good reason, such as unreasonable conduct on the part of the public body but there was no such factor present in this case.</p>
+	  <p style="text-align:justify">The Appellants appealed to the Supreme Court against the Court of Appeal&#8217;s judgment, on the basis that there is no such legal principle.</p>
+	</content>
+      </level>
+      <level>
+	<heading class="SectionHeading">Judgment</heading>
+	<content>
+	  <p style="text-align:justify">The Supreme Court unanimously allows the appeals. Lady Rose gives the judgment with which the other members of the Court agree.</p>
+	</content>
+      </level>
+      <level>
+	<heading class="SectionHeading">Reasons for the Judgment</heading>
+	<content>
+	  <p style="text-align:justify">Since its early caselaw the CAT has in general applied as a starting point in appeals brought under the Competition Act 1998 that an unsuccessful party will pay the successful party&#8217;s costs (known as &#8220;costs follow the event&#8221;) <span style="font-weight:bold">[39],[42]</span>.</p>
+	  <p style="text-align:justify">In the Supreme Court&#8217;s judgment, there is no generally applicable principle that all public bodies should enjoy a protected costs position when they lose a case. The principle supported by the <span style="font-style:italic">Booth </span>line of cases is, rather, that an important factor to consider when determining costs awards is the risk that there will be a chilling effect on the conduct of the public body if costs orders are routinely made against it when it is unsuccessful even where it has acted reasonably. Whether there is a real risk of such a chilling effect depends on the facts and circumstances of the public body in question and the nature of the decision which it is defending &#8211; it cannot be assumed that there is a risk just because the respondent to the appeal is a body acting in the public interest <span style="font-weight:bold">[97]-[98]</span>.</p>
+	  <p style="text-align:justify">Further, the assessment as to whether a chilling effect is sufficiently plausible is an assessment best made by the court or tribunal in question, subject to the supervisory jurisdiction of the appellate courts. In this case, therefore, the CAT was best placed to consider the plausibility of any chilling effect arising from making a costs order against the CMA <span style="font-weight:bold">[98]</span> and against any other public bodies which regularly appear as respondents in the wide variety of appeals over which the CAT has jurisdiction.</p>
+	  <p style="text-align:justify">On whether the CAT was correct to adopt a &#8220;costs follow the event&#8221; starting point, the Supreme Court observes that this practice was well-established when the 2015 Rules were introduced preserving the CAT&#8217;s broad costs discretion conferred by earlier versions of those rules <span style="font-weight:bold">[120]</span>. Further, the way that the CMA&#8217;s functions are funded by the Government dispels any concern that its conduct will be influenced by the risk of adverse costs orders. This is because, in effect, the CMA can set-off any adverse costs orders against the income it receives from fines imposed on companies for competition law infringements <span style="font-weight:bold">[123]-[126]</span>. There are also good policy reasons to adopt a starting point of costs follow the event.  It is right that the CMA is subjected to the discipline associated with having to pay a successful Appellant&#8217;s costs if ultimately the CAT concludes that the CMA&#8217;s actions were not well-founded <span style="font-weight:bold">[135]</span>.</p>
+	  <p style="text-align:justify">The Court also notes that the factors considered in <span style="font-style:italic">Booth </span>may legitimately be accommodated by the outcome of a costs award even if costs follow the event is taken as the starting point. A review of the CAT&#8217;s decisions on costs reveals a range of ways in which the CAT can and does tailor the costs award it makes in any particular case to reflect the many competing factors pulling in different directions <span style="font-weight:bold">[136]-[150]</span>. The CAT has developed a sophisticated approach to costs awards appreciating the need to strike a balance between maintaining flexibility in dealing with a wide range of different situations, whilst providing predictability and consistency of decision making so that the parties know what to expect if they win or lose the case. The CAT&#8217;s case law also strikes a balance between ensuring that costs awards do not undermine the effectiveness of the competition or regulatory regime and ensuring a just result for both parties <span style="font-weight:bold">[153]</span>.</p>
+	  <p style="text-align:justify">As a result, the Supreme Court concludes that the CAT&#8217;s Costs Ruling adopting a &#8220;costs follow the event&#8221; starting point was a proper exercise of its costs jurisdiction, arrived at after considering all relevant factors <span style="font-weight:bold">[154]</span>. The Supreme Court therefore allows both appeals and reinstates the CAT&#8217;s Costs Ruling <span style="font-weight:bold">[156]</span>.</p>
+	  <p class="StyleSubsectionHeadingNounderline">References in square brackets are to paragraphs in the judgment</p>
+	  <p class="Note">NOTE:</p>
+	  <p class="Note">This summary is provided to assist in understanding the Court&#8217;s decision. It does not form part of the reasons for the decision. The full judgment of the Court is the only authoritative document. Judgments are public documents and are available at: <a href="https://www.supremecourt.uk/decided-cases/index.html" class="Hyperlink">Decided cases - The Supreme Court</a></p>
+	</content>
+      </level>
+    </mainBody>
+  </doc>
+</akomaNtoso>

--- a/src/tests/lambda_tests/enrichment_lambda/test_api.py
+++ b/src/tests/lambda_tests/enrichment_lambda/test_api.py
@@ -41,6 +41,17 @@ def test_lock_judgment_non_201_raises(mock_pool_manager):
         api.lock_judgment("https://api.example/", "uksc/2024/1", "user", "pass")
 
 
+@patch("lambdas.enrichment_lambda.api.urllib3.PoolManager")
+def test_unlock_judgment_non_204_or_200_raises(mock_pool_manager):
+    response = Mock()
+    response.status = 500
+    response.data.decode.return_value = "error"
+    mock_pool_manager.return_value.request.return_value = response
+
+    with pytest.raises(RuntimeError, match="Failed to unlock judgment"):
+        api.unlock_judgment("https://api.example/", "uksc/2024/1", "user", "pass")
+
+
 @patch("lambdas.enrichment_lambda.api.requests.patch")
 def test_patch_judgment_http_error_raises_runtime_error(mock_patch):
     response = Mock()

--- a/src/tests/lambda_tests/enrichment_lambda/test_enrich_judgment.py
+++ b/src/tests/lambda_tests/enrichment_lambda/test_enrich_judgment.py
@@ -7,6 +7,7 @@ from utils.custom_types import APIEndpointBaseURL
 
 
 class TestEnrichJudgment:
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
@@ -17,6 +18,7 @@ class TestEnrichJudgment:
         mock_lock,
         mock_enrich,
         mock_patch,
+        mock_unlock,
     ):
         uri_reference = "uksc/2024/1"
         endpoint = APIEndpointBaseURL("https://api.example/")
@@ -43,8 +45,10 @@ class TestEnrichJudgment:
             enrichment_version="7.4.0",
         )
         mock_patch.assert_called_once_with(endpoint, "uksc/2024/1", "<enriched/>", "user", "pass")
+        mock_unlock.assert_not_called()
 
     @patch("boto3.resource")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
@@ -55,6 +59,7 @@ class TestEnrichJudgment:
         mock_lock,
         mock_enrich,
         mock_patch,
+        mock_unlock,
         mock_s3_resource,
     ):
         uri_reference = "uksc/2024/1"
@@ -77,12 +82,14 @@ class TestEnrichJudgment:
         mock_s3_resource.return_value.Object.assert_called_once_with("vcite-bucket", "uksc/2024/1.xml")
         mock_s3_object.put.assert_called_once()
         mock_patch.assert_not_called()
+        mock_unlock.assert_not_called()
 
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.fetch_judgment")
-    def test_enrich_judgment_fetch_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch):
+    def test_enrich_judgment_fetch_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch, mock_unlock):
         mock_fetch.side_effect = Exception("API error")
         uri_reference = "uksc/2024/1"
         endpoint = APIEndpointBaseURL("https://api.example/")
@@ -93,12 +100,14 @@ class TestEnrichJudgment:
         mock_lock.assert_called()
         mock_enrich.assert_not_called()
         mock_patch.assert_not_called()
+        mock_unlock.assert_called_once_with(endpoint, "uksc/2024/1", "user", "pass")
 
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.fetch_judgment", return_value="<xml/>")
-    def test_enrich_judgment_patch_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch):
+    def test_enrich_judgment_patch_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch, mock_unlock):
         mock_patch.side_effect = Exception("Patch failed")
         uri_reference = "uksc/2024/1"
         endpoint = APIEndpointBaseURL("https://api.example/")
@@ -109,8 +118,11 @@ class TestEnrichJudgment:
         mock_fetch.assert_called_once()
         mock_lock.assert_called_once()
         mock_enrich.assert_called_once()
+        mock_patch.assert_called_once_with(endpoint, "uksc/2024/1", "<enriched/>", "user", "pass")
+        mock_unlock.assert_called_once_with(endpoint, "uksc/2024/1", "user", "pass")
 
     @patch("boto3.resource")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
@@ -121,6 +133,7 @@ class TestEnrichJudgment:
         mock_lock,
         mock_enrich,
         mock_patch,
+        mock_unlock,
         mock_s3_resource,
     ):
         mock_s3_object = mock_s3_resource.return_value.Object.return_value
@@ -140,12 +153,14 @@ class TestEnrichJudgment:
             )
 
         mock_patch.assert_not_called()
+        mock_unlock.assert_called_once_with(endpoint, "uksc/2024/1", "user", "pass")
 
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.fetch_judgment", return_value="<xml/>")
-    def test_enrich_judgment_lock_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch):
+    def test_enrich_judgment_lock_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch, mock_unlock):
         mock_lock.side_effect = Exception("Lock failed")
         uri_reference = "uksc/2024/1"
         endpoint = APIEndpointBaseURL("https://api.example/")
@@ -156,12 +171,14 @@ class TestEnrichJudgment:
         mock_fetch.assert_not_called()
         mock_enrich.assert_not_called()
         mock_patch.assert_not_called()
+        mock_unlock.assert_not_called()
 
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.fetch_judgment", return_value="<xml/>")
-    def test_enrich_judgment_enrich_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch):
+    def test_enrich_judgment_enrich_failure(self, mock_fetch, mock_lock, mock_enrich, mock_patch, mock_unlock):
         mock_enrich.side_effect = Exception("Enrichment pipeline failed")
         uri_reference = "uksc/2024/1"
         endpoint = APIEndpointBaseURL("https://api.example/")
@@ -172,12 +189,40 @@ class TestEnrichJudgment:
         mock_fetch.assert_called_once()
         mock_lock.assert_called_once()
         mock_patch.assert_not_called()
+        mock_unlock.assert_called_once_with(endpoint, "uksc/2024/1", "user", "pass")
 
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.fetch_judgment", return_value="<xml/>")
+    def test_enrich_judgment_unlock_failure_does_not_mask_original_error(
+        self,
+        mock_fetch,
+        mock_lock,
+        mock_enrich,
+        mock_patch,
+        mock_unlock,
+    ):
+        mock_enrich.side_effect = Exception("Enrichment pipeline failed")
+        mock_unlock.side_effect = RuntimeError("Unlock failed")
+        uri_reference = "uksc/2024/1"
+        endpoint = APIEndpointBaseURL("https://api.example/")
+
+        with pytest.raises(Exception, match="Enrichment pipeline failed"):
+            enrich_judgment(uri_reference, endpoint, "user", "pass", [])
+
+        mock_fetch.assert_called_once()
+        mock_lock.assert_called_once()
+        mock_patch.assert_not_called()
+        mock_unlock.assert_called_once_with(endpoint, "uksc/2024/1", "user", "pass")
+
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.fetch_judgment", return_value="<xml/>")
-    def test_enrich_judgment_with_empty_pattern_list(self, mock_fetch, mock_lock, mock_enrich, mock_patch):
+    def test_enrich_judgment_with_empty_pattern_list(self, mock_fetch, mock_lock, mock_enrich, mock_patch, mock_unlock):
         uri_reference = "uksc/2024/1"
         endpoint = APIEndpointBaseURL("https://api.example/")
 
@@ -193,8 +238,10 @@ class TestEnrichJudgment:
         mock_lock.assert_called_once()
         mock_enrich.assert_called_once_with("<xml/>", [], enrichment_version="7.4.0")
         mock_patch.assert_called_once()
+        mock_unlock.assert_not_called()
 
     @patch("boto3.resource")
+    @patch("lambdas.enrichment_lambda.enrich_judgment.unlock_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.patch_judgment")
     @patch("lambdas.enrichment_lambda.enrich_judgment.enrich_xml", return_value="<enriched/>")
     @patch("lambdas.enrichment_lambda.enrich_judgment.lock_judgment")
@@ -205,6 +252,7 @@ class TestEnrichJudgment:
         mock_lock,
         mock_enrich,
         mock_patch,
+        mock_unlock,
         mock_s3_resource,
     ):
         uri_reference = "uksc/2024/1"
@@ -224,3 +272,4 @@ class TestEnrichJudgment:
         mock_s3_resource.return_value.Object.assert_called_once_with("", "uksc/2024/1.xml")
         mock_s3_object.put.assert_called_once()
         mock_patch.assert_not_called()
+        mock_unlock.assert_not_called()

--- a/src/tests/lambda_tests/enrichment_lambda/test_steps.py
+++ b/src/tests/lambda_tests/enrichment_lambda/test_steps.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import lxml.etree
+
 from lambdas.enrichment_lambda.steps import (
     make_post_header_replacements,
     replace_legislation_provisions,
@@ -59,6 +61,24 @@ class TestMakePostHeaderReplacements:
         content_with_replacements = make_post_header_replacements(original_file_content, replacement_content)
 
         assert_equal_xml(content_with_replacements, expected_file_content)
+
+    def test_press_summary_without_header_does_not_crash(self):
+        """pressSummary documents have no <header> element; the entire document
+        becomes the replacement target.  Previously this caused an XMLSyntaxError
+        because the XML declaration ended up wrapped inside a root element."""
+        original_file_content = open(
+            FIXTURE_DIR / "uksc-2022-14-press-summary.xml",
+            encoding="utf-8",
+        ).read()
+        # "Competition Act 1998" appears as plain text in the press summary body
+        replacement_content = '{"leg": ["Competition Act 1998", "https://www.legislation.gov.uk/ukpga/1998/41/contents", "Competition Act 1998"]}'
+
+        result = make_post_header_replacements(original_file_content, replacement_content)
+
+        lxml.etree.fromstring(result.encode("utf-8"))
+        # The legislation reference must have been tagged
+        assert 'uk:type="legislation"' in result
+        assert "Competition Act 1998" in result
 
     def test_post_header_double_replacement(self):
         """When a value is replaced, the value is an attribute in a ref tag.


### PR DESCRIPTION
## Changes in this PR:
- Add split_xml_declaration function and update make_post_header_replacements to handle press summaries not having a header section
- Unlock document if enrichment fails for any reason

### Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCLC-2132